### PR TITLE
fix(ui): use semantic css variables for tags to fix dark mode interaction

### DIFF
--- a/src/pages/groups/index.astro
+++ b/src/pages/groups/index.astro
@@ -44,7 +44,7 @@ const groups = groupsData as ResearchGroup[];
 					<div aria-hidden="true" class="w-12 h-12 rounded-xl bg-gradient-to-br from-premium-accent/10 to-premium-purple/10 border border-border-main flex items-center justify-center text-premium-accent font-bold">
 						{group.short_name.charAt(0)}
 					</div>
-					<span class="px-3 py-1 rounded-full bg-[#e2e8f0] dark:bg-[#1e293b] text-[10px] font-bold text-text-secondary uppercase tracking-wider border border-border-main">
+					<span class="px-3 py-1 rounded-full bg-[var(--color-tag-bg)] text-[10px] font-bold text-text-secondary uppercase tracking-wider border border-border-main">
 						{group.campus.name}
 					</span>
 				</div>
@@ -58,12 +58,12 @@ const groups = groupsData as ResearchGroup[];
 
 				<div class="flex flex-wrap gap-2 mb-6" aria-label="Áreas de conhecimento">
 					{group.knowledge_areas.slice(0, 2).map(area => (
-						<span class="px-2 py-0.5 rounded-md bg-[#f1f5f9] dark:bg-[#1e293b] text-[10px] font-bold text-text-secondary border border-border-main">
+						<span class="px-2 py-0.5 rounded-md bg-[var(--color-tag-bg-accent)] text-[10px] font-bold text-text-secondary border border-border-main">
 							{area.name}
 						</span>
 					))}
 					{group.knowledge_areas.length > 2 && (
-						<span class="px-2 py-0.5 rounded-md bg-[#f1f5f9] dark:bg-[#1e293b] text-[10px] font-bold text-text-secondary">
+						<span class="px-2 py-0.5 rounded-md bg-[var(--color-tag-bg-accent)] text-[10px] font-bold text-text-secondary">
 							+{group.knowledge_areas.length - 2}
 						</span>
 					)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,9 @@
     --color-text-main: var(--text-primary);
     --color-text-muted: var(--text-secondary);
     --color-border-main: var(--border-primary);
+    /* Tag Colors */
+    --color-tag-bg: var(--tag-bg);
+    --color-tag-bg-accent: var(--tag-bg-accent);
     --color-glass-bg: var(--glass-surface);
 
     /* Brand/Accent Colors (WCAG Compliant) */
@@ -29,6 +32,10 @@
         --glass-surface: rgba(255, 255, 255, 0.7);
         --page-gradient: radial-gradient(circle at 50% 50%, #f1f5f9 0%, #cbd5e1 100%);
 
+        /* Tag System Defaults (Light) */
+        --tag-bg: #e2e8f0;
+        --tag-bg-accent: #f1f5f9;
+
         /* Override accents for light mode if needed for better contrast */
         --color-premium-accent: #0369a1;
         /* sky-700 */
@@ -44,6 +51,10 @@
         --border-primary: rgba(255, 255, 255, 0.1);
         --glass-surface: rgba(15, 23, 42, 0.4);
         --page-gradient: radial-gradient(circle at 50% 50%, #1e293b 0%, #020617 100%);
+
+        /* Tag System Overrides (Dark) */
+        --tag-bg: #1e293b;
+        --tag-bg-accent: #1e293b;
 
         --color-premium-accent: #38bdf8;
         /* sky-400 */


### PR DESCRIPTION
**Description**
Fixed the issue where knowledge area tags and campus badges appeared unreadable (dark text on dark background) when the user's OS is in Dark Mode but the website is in Light Mode.
This happened because `dark:` utility classes triggered based on OS preference (media query) while the rest of the site (cards, text) obeyed the CSS class strategy.

**Changes**
- Replaced `dark:` modifiers with semantic CSS variables (`--tag-bg`, `--tag-bg-accent`).
- Defined these variables in `global.css` to switch strictly based on the presence of the `.dark` class.
- Updated `src/pages/groups/index.astro` to consume these variables.

**Verification**
- Tags should now be light gray (`#e2e8f0`) in Light Mode, regardless of OS setting.
- Tags should be dark slate (`#1e293b`) in Dark Mode (when site theme is toggled).

**Closes**
Closes #6