### PR TITLE
release: v1.0.2 fix ui contrast and dark mode conflicts

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -19,7 +19,10 @@ Reflecting active work from `SI.3 Product Backlog`.
 
 - **Epic 1: Extração SigPesq (Release 1)**
     - [x] US-001 [Extração Projetos SigPesq](https://github.com/ifesserra-lab/horizon_etl/issues/2) (Merged)
-    - [Release v1.0.0](https://github.com/ifesserra-lab/horizon_dashboard/releases/tag/v1.0.0) | 2026-01-10
+    - [Release v1.0.1](https://github.com/ifesserra-lab/horizon_dashboard/releases/tag/v1.0.1) | 2026-01-10
+    - [PR #7](https://github.com/ifesserra-lab/horizon_dashboard/pull/7) - Fix CSS Dark Mode Strategy (Merged)
+    - [Issue #6](https://github.com/ifesserra-lab/horizon_dashboard/issues/6) - Fix CSS Dark Mode Mismatch (Closed)
+- [Release v1.0.0](https://github.com/ifesserra-lab/horizon_dashboard/releases/tag/v1.0.0) | 2026-01-10
     - [PR #1](https://github.com/ifesserra-lab/horizon_dashboard/pull/1) - Initialize Project
     - [Issue #3](https://github.com/ifesserra-lab/horizon_dashboard/issues/3) - Fix Breadcrumb Navigation (Closed)
     - [Issue #4](https://github.com/ifesserra-lab/horizon_dashboard/issues/4) - Fix CSS Contrast Light Mode (Closed)

--- a/src/pages/groups/[id].astro
+++ b/src/pages/groups/[id].astro
@@ -40,7 +40,7 @@ const { group } = Astro.props;
 								<span class="px-3 py-1 rounded-full bg-premium-accent/10 text-premium-accent text-[10px] font-bold uppercase tracking-widest border border-premium-accent/20">
 									{group.organization.name}
 								</span>
-								<span class="px-3 py-1 rounded-full bg-slate-200 dark:bg-slate-800 text-text-secondary text-[10px] font-bold uppercase tracking-widest border border-border-main">
+								<span class="px-3 py-1 rounded-full bg-[var(--tag-bg)] text-text-secondary text-[10px] font-bold uppercase tracking-widest border border-border-main">
 									{group.campus.name}
 								</span>
 							</div>
@@ -48,7 +48,7 @@ const { group } = Astro.props;
 						</div>
 					</div>
 					{group.cnpq_url && (
-						<a href={group.cnpq_url} target="_blank" rel="noopener noreferrer" class="px-6 py-3 bg-slate-100 dark:bg-white/5 hover:bg-premium-accent/10 border border-border-main rounded-xl text-xs font-bold transition-all flex items-center gap-2 text-text-main focus:ring-2 focus:ring-premium-accent">
+						<a href={group.cnpq_url} target="_blank" rel="noopener noreferrer" class="px-6 py-3 bg-[var(--tag-bg)] hover:bg-premium-accent/10 border border-border-main rounded-xl text-xs font-bold transition-all flex items-center gap-2 text-text-main focus:ring-2 focus:ring-premium-accent">
 							Espelho CNPq
 							<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
 						</a>
@@ -66,7 +66,7 @@ const { group } = Astro.props;
 					<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-4">Áreas de Conhecimento</h4>
 					<div class="flex flex-wrap gap-3" role="list" aria-label="Áreas de atuação">
 						{group.knowledge_areas.map(area => (
-							<div role="listitem" class="px-4 py-2 bg-slate-100 dark:bg-slate-800/50 border border-border-main rounded-xl text-xs text-text-main font-bold">
+							<div role="listitem" class="px-4 py-2 bg-[var(--tag-bg)] border border-border-main rounded-xl text-xs text-text-main font-bold">
 								{area.name}
 							</div>
 						))}
@@ -83,7 +83,7 @@ const { group } = Astro.props;
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 					{group.members.map(member => (
 						<div class="glass-card p-4 flex items-center gap-4 hover:border-premium-accent/30 transition-all">
-							<div aria-hidden="true" class="w-12 h-12 rounded-full bg-slate-200 dark:bg-slate-800 border-2 border-border-main flex items-center justify-center text-text-secondary font-bold">
+							<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold">
 								{member.name.charAt(0)}
 							</div>
 							<div class="flex-1 overflow-hidden">
@@ -93,7 +93,7 @@ const { group } = Astro.props;
 								</p>
 							</div>
 							{member.lattes_url && (
-								<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-slate-100 dark:bg-white/5 hover:bg-premium-accent/10 text-text-secondary hover:text-premium-accent transition-all focus:ring-2 focus:ring-premium-accent" aria-label={`Currículo Lattes de ${member.name}`}>
+								<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-accent/10 text-text-secondary hover:text-premium-accent transition-all focus:ring-2 focus:ring-premium-accent" aria-label={`Currículo Lattes de ${member.name}`}>
 									<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
 								</a>
 							)}

--- a/src/pages/groups/index.astro
+++ b/src/pages/groups/index.astro
@@ -44,7 +44,7 @@ const groups = groupsData as ResearchGroup[];
 					<div aria-hidden="true" class="w-12 h-12 rounded-xl bg-gradient-to-br from-premium-accent/10 to-premium-purple/10 border border-border-main flex items-center justify-center text-premium-accent font-bold">
 						{group.short_name.charAt(0)}
 					</div>
-					<span class="px-3 py-1 rounded-full bg-[var(--color-tag-bg)] text-[10px] font-bold text-text-secondary uppercase tracking-wider border border-border-main">
+					<span class="px-3 py-1 rounded-full bg-[var(--tag-bg)] text-[10px] font-bold text-text-secondary uppercase tracking-wider border border-border-main">
 						{group.campus.name}
 					</span>
 				</div>
@@ -58,12 +58,12 @@ const groups = groupsData as ResearchGroup[];
 
 				<div class="flex flex-wrap gap-2 mb-6" aria-label="Áreas de conhecimento">
 					{group.knowledge_areas.slice(0, 2).map(area => (
-						<span class="px-2 py-0.5 rounded-md bg-[var(--color-tag-bg-accent)] text-[10px] font-bold text-text-secondary border border-border-main">
+						<span class="px-2 py-0.5 rounded-md bg-[var(--tag-bg)] text-[10px] font-bold text-text-secondary border border-border-main">
 							{area.name}
 						</span>
 					))}
 					{group.knowledge_areas.length > 2 && (
-						<span class="px-2 py-0.5 rounded-md bg-[var(--color-tag-bg-accent)] text-[10px] font-bold text-text-secondary">
+						<span class="px-2 py-0.5 rounded-md bg-[var(--tag-bg)] text-[10px] font-bold text-text-secondary">
 							+{group.knowledge_areas.length - 2}
 						</span>
 					)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,8 +32,8 @@
         --glass-surface: rgba(255, 255, 255, 0.7);
         --page-gradient: radial-gradient(circle at 50% 50%, #f1f5f9 0%, #cbd5e1 100%);
 
-        /* Tag System Defaults (Light) */
-        --tag-bg: #e2e8f0;
+        /* Tag Backgrounds (Light) */
+        --tag-bg: #f1f5f9;
         --tag-bg-accent: #f1f5f9;
 
         /* Override accents for light mode if needed for better contrast */
@@ -52,7 +52,7 @@
         --glass-surface: rgba(15, 23, 42, 0.4);
         --page-gradient: radial-gradient(circle at 50% 50%, #1e293b 0%, #020617 100%);
 
-        /* Tag System Overrides (Dark) */
+        /* Tag Backgrounds (Dark) */
         --tag-bg: #1e293b;
         --tag-bg-accent: #1e293b;
 


### PR DESCRIPTION
**Release v1.0.2**
Includes robust fix for UI Contrast issues where tags were dark in light mode due to OS settings.
- Standardized tag backgrounds to `#f1f5f9` (Slate 100) in Light Mode (ignoring OS preference).
- Standardized tag backgrounds to `#1e293b` (Slate 800) in Dark Mode.
- Applied to Group List and Detail pages consistently.

**Changes**
- `global.css`: Defined `--tag-bg` logic.
- Atomic updates to components.

**Closes**
- Issue #9
- Issue #6 (reopened/verified)