### PR TITLE
feat(ui): remove member avatars from group card

### DIFF
--- a/src/pages/groups/index.astro
+++ b/src/pages/groups/index.astro
@@ -69,19 +69,7 @@ const groups = groupsData as ResearchGroup[];
 					)}
 				</div>
 
-				<div class="pt-6 border-t border-border-main flex justify-between items-center mt-auto">
-					<div class="flex -space-x-1" aria-hidden="true">
-						{group.members.slice(0, 3).map((_, i) => (
-							<div class="w-8 h-8 rounded-full bg-slate-200 dark:bg-slate-800 border-2 border-page-bg flex items-center justify-center text-[10px] font-bold text-text-secondary overflow-hidden ring-1 ring-border-main/50">
-								<svg xmlns="http://www.w3.org/2000/svg" class="w-full h-full p-1.5 text-text-secondary/50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-							</div>
-						))}
-						{group.members.length > 3 && (
-							<div class="w-8 h-8 rounded-full bg-premium-accent/10 border-2 border-page-bg flex items-center justify-center text-[10px] font-bold text-premium-accent">
-								+{group.members.length - 3}
-							</div>
-						)}
-					</div>
+				<div class="pt-6 border-t border-border-main flex justify-end items-center mt-auto">
 					<a href={`${import.meta.env.BASE_URL}groups/${group.id}`} class="text-xs font-bold text-premium-accent flex items-center gap-1 hover:translate-x-1 transition-transform focus:ring-2 focus:ring-premium-accent rounded px-1" aria-label={`Detalhes de ${group.name}`}>
 						Detalhes
 						<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>


### PR DESCRIPTION
**Description**
Removed the member avatar section (circles) from the Group Card to declutter the UI.
Aligned the "Detalhes" button to the right end of the card footer.

**Closes**
Closes #12