### PR TITLE
release: v1.2.2 - Fix Home Charts Clipping

### DIFF
--- a/docs/1 - projeto/PM1.9-status_report_1.md
+++ b/docs/1 - projeto/PM1.9-status_report_1.md
@@ -46,6 +46,7 @@ A **Release R1 (Portal de Grupos)** foi refinada com a integração de dados rea
 | **US-033** | Refinement: Team Evolution | **Entregue** | v1.1.7 |
 | **US-034** | Visual Standardization (Headers) | **Entregue** | v1.2.0 |
 | **US-035** | Home Page Analytics (Refined) | **Entregue** | v1.2.1 |
+| **Bugfix** | Home Chart Clipping | **Entregue** | v1.2.2 |
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,6 +7,7 @@ Tracks the delivery of versions to production (Main Branch).
 
 | Version | Date | Status | Description |
 |---------|------|--------|-------------|
+| **v1.2.2** | 2026-01-16 | **Released** | Bugfix: Home Chart Hover Clipping |
 | **v1.2.1** | 2026-01-16 | **Released** | Refinement: Home Analytics (Interaction + Bugfix) |
 | **v1.2.0** | 2026-01-16 | **Released** | Feature: Visual Standards & Ecosystem Analytics |
 | **v1.1.7** | 2026-01-16 | **Released** | Refinement: Team Evolution data & Dashboard Polishing |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "horizon",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/src/components/home/HomeCharts.astro
+++ b/src/components/home/HomeCharts.astro
@@ -209,7 +209,8 @@ const linePath = points.reduce((acc: string, p: any, i: number) =>
 
         <div class="w-full md:w-1/2 flex justify-center relative">
              <div class="relative w-48 h-48">
-                <svg viewBox="0 0 100 100" class="w-full h-full -rotate-90">
+                <!-- Expanded viewBox to prevent clipping on hover scale -->
+                <svg viewBox="-10 -10 120 120" class="w-full h-full -rotate-90 overflow-visible">
                     {donutData.map(slice => (
                         <a href={`/horizon_dashboard/groups?search=${encodeURIComponent(slice.name)}`} class="group/slice">
                             <path 


### PR DESCRIPTION
## Release v1.2.2: Fix Home Charts Clipping

### Bug Fixes
- **UI**: Expanded the `viewBox` of the Groups Distribution (Donut) Chart from `0 0 100 100` to `-10 -10 120 120`.
- **Reason**: The hover effect scales chart slices by 5% (`scale-105`), which was causing the outer edges of the chart to be clipped by the SVG boundary. This fix ensures smooth, unclipped hover interactions.
