### PR TITLE
feat(groups): add projects section to research group details

### DIFF
--- a/dist/groups/index.html
+++ b/dist/groups/index.html
@@ -1,76 +1,78 @@
 <!DOCTYPE html><html lang="pt-BR" class="dark"> <head><meta charset="UTF-8"><meta name="description" content="Horizon - Portal de Pesquisa, Extensão e Pós-Graduação"><meta name="viewport" content="width=device-width"><link rel="icon" type="image/svg+xml" href="/horizon_dashboard/favicon.svg"><meta name="generator" content="Astro v5.16.8"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:url" content="https://ifesserra-lab.github.io/horizon_dashboard/groups/"><meta property="og:title" content="Grupos de Pesquisa | Horizon"><meta property="og:description" content="Horizon - Portal de Pesquisa, Extensão e Pós-Graduação"><meta property="og:image" content="https://ifesserra-lab.github.io/horizon_dashboard/og-image.png"><meta property="og:site_name" content="Horizon"><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:url" content="https://ifesserra-lab.github.io/horizon_dashboard/groups/"><meta property="twitter:title" content="Grupos de Pesquisa | Horizon"><meta property="twitter:description" content="Horizon - Portal de Pesquisa, Extensão e Pós-Graduação"><meta property="twitter:image" content="https://ifesserra-lab.github.io/horizon_dashboard/og-image.png"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700&display=swap" rel="stylesheet"><title>Grupos de Pesquisa | Horizon</title><script>
-			// Theme detection with Auto mode support
-			const themePreference = (() => {
-				if (
-					typeof localStorage !== "undefined" &&
-					localStorage.getItem("theme-preference")
-				) {
-					return localStorage.getItem("theme-preference");
+			// Function to apply all settings from localStorage
+			function applyThemeSettings() {
+				if (typeof localStorage === "undefined") return;
+
+				// 1. Theme
+				const themePreference =
+					localStorage.getItem("theme-preference") || "auto";
+				let theme = themePreference;
+
+				if (theme === "auto") {
+					theme = window.matchMedia("(prefers-color-scheme: dark)")
+						.matches
+						? "dark"
+						: "light";
 				}
-				return "auto";
-			})();
 
-			let theme = themePreference;
-			if (theme === "auto") {
-				theme = window.matchMedia("(prefers-color-scheme: dark)")
-					.matches
-					? "dark"
-					: "light";
-			}
+				if (theme === "light") {
+					document.documentElement.classList.remove("dark");
+				} else {
+					document.documentElement.classList.add("dark");
+				}
 
-			if (theme === "light") {
-				document.documentElement.classList.remove("dark");
-			} else {
-				document.documentElement.classList.add("dark");
-			}
+				// 2. Contrast
+				const contrast = localStorage.getItem("contrast") || "normal";
+				document.documentElement.classList.remove(
+					"contrast-high",
+					"contrast-maximum",
+				);
+				if (contrast === "high") {
+					document.documentElement.classList.add("contrast-high");
+				} else if (contrast === "maximum") {
+					document.documentElement.classList.add("contrast-maximum");
+				}
 
-			// Store the preference (not the resolved theme)
-			if (typeof localStorage !== "undefined") {
-				localStorage.setItem("theme-preference", themePreference);
-				// Also keep legacy 'theme' for backwards compatibility
-				localStorage.setItem("theme", theme);
-			}
+				// Legacy migration
+				if (
+					localStorage.getItem("high-contrast") === "true" &&
+					!localStorage.getItem("contrast")
+				) {
+					document.documentElement.classList.add("contrast-high");
+					localStorage.setItem("contrast", "high");
+				}
 
-			// Contrast Level (replaces old high-contrast boolean)
-			const contrast = localStorage.getItem("contrast") || "normal";
-			if (contrast === "high") {
-				document.documentElement.classList.add("contrast-high");
-			} else if (contrast === "maximum") {
-				document.documentElement.classList.add("contrast-maximum");
-			}
+				// 3. Font Scale
+				const textScale = localStorage.getItem("text-scale") || "base";
+				const scales = ["sm", "base", "lg", "xl"];
+				scales.forEach((s) => {
+					document.documentElement.classList.toggle(
+						`text-scale-${s}`,
+						textScale === s,
+					);
+				});
 
-			// Legacy high-contrast migration
-			if (
-				localStorage.getItem("high-contrast") === "true" &&
-				!localStorage.getItem("contrast")
-			) {
-				document.documentElement.classList.add("contrast-high");
-				localStorage.setItem("contrast", "high");
-			}
-
-			// Font Scaling
-			const textScale = localStorage.getItem("text-scale") || "base";
-			const scales = ["sm", "base", "lg", "xl"];
-			scales.forEach((s) => {
+				// 4. Additional Options
 				document.documentElement.classList.toggle(
-					`text-scale-${s}`,
-					textScale === s,
+					"reduce-motion",
+					localStorage.getItem("reduce-motion") === "true",
 				);
-			});
-
-			// Additional Accessibility Options
-			if (localStorage.getItem("reduce-motion") === "true") {
-				document.documentElement.classList.add("reduce-motion");
-			}
-			if (localStorage.getItem("enhanced-focus") === "true") {
-				document.documentElement.classList.add("enhanced-focus");
-			}
-			if (localStorage.getItem("screen-reader-optimized") === "true") {
-				document.documentElement.classList.add(
+				document.documentElement.classList.toggle(
+					"enhanced-focus",
+					localStorage.getItem("enhanced-focus") === "true",
+				);
+				document.documentElement.classList.toggle(
 					"screen-reader-optimized",
+					localStorage.getItem("screen-reader-optimized") === "true",
 				);
 			}
-		</script><link rel="stylesheet" href="/horizon_dashboard/_astro/_id_.CvhXe4Jt.css"></head> <body class="bg-page-bg text-text-main font-['Inter'] min-h-screen selection:bg-premium-accent/30 transition-colors duration-300"> <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-premium-accent focus:text-white rounded-br-xl shadow-xl">
+
+			// Apply on initial load
+			applyThemeSettings();
+
+			// Re-apply on View Transitions navigation (astro:after-swap)
+			document.addEventListener("astro:after-swap", applyThemeSettings);
+		</script><link rel="stylesheet" href="/horizon_dashboard/_astro/_id_.Cbdq2Lma.css"></head> <body class="bg-page-bg text-text-main font-['Inter'] min-h-screen selection:bg-premium-accent/30 transition-colors duration-300"> <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-premium-accent focus:text-white rounded-br-xl shadow-xl">
 Pular para o conteúdo principal
 </a> <div class="flex flex-col md:flex-row min-h-screen"> <!-- Mobile Header --> <header class="md:hidden h-16 glass-card rounded-none border-x-0 border-t-0 flex items-center justify-between px-6 z-30 sticky top-0"> <div class="flex items-center gap-3"> <div class="w-8 h-8 bg-gradient-to-br from-premium-accent to-premium-purple rounded-lg shadow-lg flex items-center justify-center overflow-hidden" aria-hidden="true"> <span class="text-white font-['Outfit'] font-bold text-lg">H</span> </div> <h1 class="text-lg font-['Outfit'] font-bold bg-clip-text text-transparent bg-gradient-to-r from-text-main to-slate-400">
 Horizon

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,76 +1,78 @@
 <!DOCTYPE html><html lang="pt-BR" class="dark"> <head><meta charset="UTF-8"><meta name="description" content="Horizon - Portal de Pesquisa, Extensão e Pós-Graduação"><meta name="viewport" content="width=device-width"><link rel="icon" type="image/svg+xml" href="/horizon_dashboard/favicon.svg"><meta name="generator" content="Astro v5.16.8"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:url" content="https://ifesserra-lab.github.io/horizon_dashboard/"><meta property="og:title" content="Dashboard Overview | Horizon"><meta property="og:description" content="Horizon - Portal de Pesquisa, Extensão e Pós-Graduação"><meta property="og:image" content="https://ifesserra-lab.github.io/horizon_dashboard/og-image.png"><meta property="og:site_name" content="Horizon"><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:url" content="https://ifesserra-lab.github.io/horizon_dashboard/"><meta property="twitter:title" content="Dashboard Overview | Horizon"><meta property="twitter:description" content="Horizon - Portal de Pesquisa, Extensão e Pós-Graduação"><meta property="twitter:image" content="https://ifesserra-lab.github.io/horizon_dashboard/og-image.png"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700&display=swap" rel="stylesheet"><title>Dashboard Overview | Horizon</title><script>
-			// Theme detection with Auto mode support
-			const themePreference = (() => {
-				if (
-					typeof localStorage !== "undefined" &&
-					localStorage.getItem("theme-preference")
-				) {
-					return localStorage.getItem("theme-preference");
+			// Function to apply all settings from localStorage
+			function applyThemeSettings() {
+				if (typeof localStorage === "undefined") return;
+
+				// 1. Theme
+				const themePreference =
+					localStorage.getItem("theme-preference") || "auto";
+				let theme = themePreference;
+
+				if (theme === "auto") {
+					theme = window.matchMedia("(prefers-color-scheme: dark)")
+						.matches
+						? "dark"
+						: "light";
 				}
-				return "auto";
-			})();
 
-			let theme = themePreference;
-			if (theme === "auto") {
-				theme = window.matchMedia("(prefers-color-scheme: dark)")
-					.matches
-					? "dark"
-					: "light";
-			}
+				if (theme === "light") {
+					document.documentElement.classList.remove("dark");
+				} else {
+					document.documentElement.classList.add("dark");
+				}
 
-			if (theme === "light") {
-				document.documentElement.classList.remove("dark");
-			} else {
-				document.documentElement.classList.add("dark");
-			}
+				// 2. Contrast
+				const contrast = localStorage.getItem("contrast") || "normal";
+				document.documentElement.classList.remove(
+					"contrast-high",
+					"contrast-maximum",
+				);
+				if (contrast === "high") {
+					document.documentElement.classList.add("contrast-high");
+				} else if (contrast === "maximum") {
+					document.documentElement.classList.add("contrast-maximum");
+				}
 
-			// Store the preference (not the resolved theme)
-			if (typeof localStorage !== "undefined") {
-				localStorage.setItem("theme-preference", themePreference);
-				// Also keep legacy 'theme' for backwards compatibility
-				localStorage.setItem("theme", theme);
-			}
+				// Legacy migration
+				if (
+					localStorage.getItem("high-contrast") === "true" &&
+					!localStorage.getItem("contrast")
+				) {
+					document.documentElement.classList.add("contrast-high");
+					localStorage.setItem("contrast", "high");
+				}
 
-			// Contrast Level (replaces old high-contrast boolean)
-			const contrast = localStorage.getItem("contrast") || "normal";
-			if (contrast === "high") {
-				document.documentElement.classList.add("contrast-high");
-			} else if (contrast === "maximum") {
-				document.documentElement.classList.add("contrast-maximum");
-			}
+				// 3. Font Scale
+				const textScale = localStorage.getItem("text-scale") || "base";
+				const scales = ["sm", "base", "lg", "xl"];
+				scales.forEach((s) => {
+					document.documentElement.classList.toggle(
+						`text-scale-${s}`,
+						textScale === s,
+					);
+				});
 
-			// Legacy high-contrast migration
-			if (
-				localStorage.getItem("high-contrast") === "true" &&
-				!localStorage.getItem("contrast")
-			) {
-				document.documentElement.classList.add("contrast-high");
-				localStorage.setItem("contrast", "high");
-			}
-
-			// Font Scaling
-			const textScale = localStorage.getItem("text-scale") || "base";
-			const scales = ["sm", "base", "lg", "xl"];
-			scales.forEach((s) => {
+				// 4. Additional Options
 				document.documentElement.classList.toggle(
-					`text-scale-${s}`,
-					textScale === s,
+					"reduce-motion",
+					localStorage.getItem("reduce-motion") === "true",
 				);
-			});
-
-			// Additional Accessibility Options
-			if (localStorage.getItem("reduce-motion") === "true") {
-				document.documentElement.classList.add("reduce-motion");
-			}
-			if (localStorage.getItem("enhanced-focus") === "true") {
-				document.documentElement.classList.add("enhanced-focus");
-			}
-			if (localStorage.getItem("screen-reader-optimized") === "true") {
-				document.documentElement.classList.add(
+				document.documentElement.classList.toggle(
+					"enhanced-focus",
+					localStorage.getItem("enhanced-focus") === "true",
+				);
+				document.documentElement.classList.toggle(
 					"screen-reader-optimized",
+					localStorage.getItem("screen-reader-optimized") === "true",
 				);
 			}
-		</script><link rel="stylesheet" href="/horizon_dashboard/_astro/_id_.CvhXe4Jt.css"></head> <body class="bg-page-bg text-text-main font-['Inter'] min-h-screen selection:bg-premium-accent/30 transition-colors duration-300"> <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-premium-accent focus:text-white rounded-br-xl shadow-xl">
+
+			// Apply on initial load
+			applyThemeSettings();
+
+			// Re-apply on View Transitions navigation (astro:after-swap)
+			document.addEventListener("astro:after-swap", applyThemeSettings);
+		</script><link rel="stylesheet" href="/horizon_dashboard/_astro/_id_.Cbdq2Lma.css"></head> <body class="bg-page-bg text-text-main font-['Inter'] min-h-screen selection:bg-premium-accent/30 transition-colors duration-300"> <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-premium-accent focus:text-white rounded-br-xl shadow-xl">
 Pular para o conteúdo principal
 </a> <div class="flex flex-col md:flex-row min-h-screen"> <!-- Mobile Header --> <header class="md:hidden h-16 glass-card rounded-none border-x-0 border-t-0 flex items-center justify-between px-6 z-30 sticky top-0"> <div class="flex items-center gap-3"> <div class="w-8 h-8 bg-gradient-to-br from-premium-accent to-premium-purple rounded-lg shadow-lg flex items-center justify-center overflow-hidden" aria-hidden="true"> <span class="text-white font-['Outfit'] font-bold text-lg">H</span> </div> <h1 class="text-lg font-['Outfit'] font-bold bg-clip-text text-transparent bg-gradient-to-r from-text-main to-slate-400">
 Horizon

--- a/docs/2 - implementacao/SI3 - initiation/SI.3-product_backlog_initiation.md
+++ b/docs/2 - implementacao/SI3 - initiation/SI.3-product_backlog_initiation.md
@@ -257,6 +257,56 @@ Como usuário, quero identificar facilmente quais membros são egressos (ex-memb
 - Ícone do menu lateral idêntico ao do card "Áreas de Conhecimento" da home.
 - RF Relacionado: RF-21.
 
+### US-032 – Exibir Grupo de Pesquisa no Projeto
+**GitHub Issue**: TBD
+```yaml
+id: US-032
+milestone: R1
+prioridade: Média
+tamanho: 2
+origem: [User Request]
+tags: [type:feature, area:frontend, component:projects]
+```
+
+#### Descrição
+Adicionar o nome do Grupo de Pesquisa na seção "Informações Adicionais" da página de detalhes do projeto, para que o usuário saiba a qual grupo a iniciativa está vinculada.
+
+#### Critérios de Aceitação
+- **Funcional**:
+    - [ ] Exibir campo "Grupo de Pesquisa" na seção "Informações Adicionais".
+    - [ ] Mostrar o nome do grupo se disponível.
+    - [ ] Ocultar o campo se o projeto não tiver grupo vinculado.
+- **UI/UX**:
+    - [ ] Seguir o mesmo estilo de "Status" e "Tipo".
+
+### US-033 – Listar Projetos no Grupo de Pesquisa
+**GitHub Issue**: TBD
+```yaml
+id: US-033
+milestone: R1
+prioridade: Média
+tamanho: 3
+origem: [User Request]
+tags: [type:feature, area:frontend, component:groups]
+```
+
+#### Descrição
+Listar todos os projetos vinculados a um grupo de pesquisa na página de detalhes do grupo (`/groups/[id]`), para que os usuários possam ver as iniciativas em andamento de cada grupo.
+
+#### Critérios de Aceitação
+- **Funcional**:
+    - [ ] Criar nova seção "Projetos" na página de detalhes do grupo.
+    - [ ] Listar projetos onde `research_group.id` corresponde ao ID do grupo visitado.
+    - [ ] Exibir cards resumidos dos projetos (Título, Status, Datas).
+    - [ ] Linkar cards para detalhes do projeto (`/projects/[id]`).
+- **UI/UX**:
+    - [ ] Manter consistência visual com os cards de membros.
+    - [ ] Se não houver projetos, exibir mensagem informativa ou ocultar a seção.
+
+
+
+
+
 ## Epic 1: Extração SigPesq (Release 1)
 **Objetivo**: Coletar dados de projetos da base SigPesq.
 

--- a/src/data/canonical/initiatives_canonical.json
+++ b/src/data/canonical/initiatives_canonical.json
@@ -219,7 +219,8 @@
                 "start_date": "2022-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 2,
@@ -242,6 +243,213 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 122,
+                "person_name": "Flavio Barcelos Braz Da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 123,
+                "person_name": "Danilo De Paula E Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1099,
+                "person_name": "Giovani Zanetti Neto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1740,
+                "person_name": "Tiago Malavazi de Christo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-24T00:00:00"
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-10-05T00:00:00"
+            },
+            {
+                "person_id": 1742,
+                "person_name": "Dárcio Leitão Quintas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1743,
+                "person_name": "Felipe Morilho de Castro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1744,
+                "person_name": "Guilherme Lima Barbarioli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 4716,
+                "person_name": "Danilo de Paula e Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4717,
+                "person_name": "Edmilson Bermudes Rocha Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2851,
+                "person_name": "João Vitor Ferreira Duque",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4718,
+                "person_name": "Jussara Farias Fardin",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4719,
+                "person_name": "Renato Tannure Rotta de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-10-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4720,
+                "person_name": "Renner Sartório Camargo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-03-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1658,
+                "person_name": "Vinícius Secchin de Melo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-11-19T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 123,
                 "person_name": "Danilo De Paula E Silva",
@@ -369,7 +577,11 @@
                 "start_date": "2022-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 90,
+            "name": "Grupo de Energias Renováveis para Automação"
+        }
     },
     {
         "id": 3,
@@ -392,6 +604,537 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 2486,
                 "person_name": "Karin Satie Komati",
@@ -501,7 +1244,11 @@
                 "start_date": "2022-11-28T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 4,
@@ -524,6 +1271,537 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 2486,
                 "person_name": "Karin Satie Komati",
@@ -596,8 +1874,21 @@
                 ],
                 "start_date": "2022-12-01T00:00:00",
                 "end_date": null
+            },
+            {
+                "person_id": 4964,
+                "person_name": "Luiz Felipe Elizeta dos Santos",
+                "roles": [
+                    "Student"
+                ],
+                "start_date": "2022-12-01T00:00:00",
+                "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 5,
@@ -620,6 +1911,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 116,
                 "person_name": "Marco Antonio De Souza Leite Cuadros",
@@ -774,7 +2245,11 @@
                 "start_date": "2023-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 6,
@@ -797,6 +2272,213 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 122,
+                "person_name": "Flavio Barcelos Braz Da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 123,
+                "person_name": "Danilo De Paula E Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1099,
+                "person_name": "Giovani Zanetti Neto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1740,
+                "person_name": "Tiago Malavazi de Christo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-24T00:00:00"
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-10-05T00:00:00"
+            },
+            {
+                "person_id": 1742,
+                "person_name": "Dárcio Leitão Quintas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1743,
+                "person_name": "Felipe Morilho de Castro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1744,
+                "person_name": "Guilherme Lima Barbarioli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 4716,
+                "person_name": "Danilo de Paula e Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4717,
+                "person_name": "Edmilson Bermudes Rocha Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2851,
+                "person_name": "João Vitor Ferreira Duque",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4718,
+                "person_name": "Jussara Farias Fardin",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4719,
+                "person_name": "Renato Tannure Rotta de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-10-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4720,
+                "person_name": "Renner Sartório Camargo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-03-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1658,
+                "person_name": "Vinícius Secchin de Melo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-11-19T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 122,
                 "person_name": "Flavio Barcelos Braz Da Silva",
@@ -825,7 +2507,11 @@
                 "start_date": "2023-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 90,
+            "name": "Grupo de Energias Renováveis para Automação"
+        }
     },
     {
         "id": 7,
@@ -848,6 +2534,168 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 250,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 251,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-04-01T00:00:00",
+                "end_date": "2025-03-20T00:00:00"
+            },
+            {
+                "person_id": 2782,
+                "person_name": "Cleber Silva Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": "2021-12-18T00:00:00"
+            },
+            {
+                "person_id": 2783,
+                "person_name": "Giancarlo Oliveira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-07T00:00:00"
+            },
+            {
+                "person_id": 2784,
+                "person_name": "Harrison Felipe Sanches Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-12-18T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4724,
+                "person_name": "Fábio de Oliveira Lima",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4725,
+                "person_name": "Gilmar Luiz Vassoler",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4726,
+                "person_name": "Adailton Saraiva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1569,
+                "person_name": "Alan Pancieri Berger Saar",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4727,
+                "person_name": "Ana Júlia Caetano Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4728,
+                "person_name": "Bruno Moreto de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4729,
+                "person_name": "Eduarda Nascimento Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4730,
+                "person_name": "Jeorge Terci Gasperazzo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4731,
+                "person_name": "Leonardo Zuchi Guio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3814,
                 "person_name": "Maxwell Eduardo Monteiro",
@@ -885,7 +2733,11 @@
                 "start_date": "2023-01-27T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 178,
+            "name": "Grupo de Pesquisa em Redes e Otimização"
+        }
     },
     {
         "id": 8,
@@ -908,6 +2760,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 116,
                 "person_name": "Marco Antonio De Souza Leite Cuadros",
@@ -1035,7 +3067,11 @@
                 "start_date": "2023-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 9,
@@ -1058,6 +3094,213 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 122,
+                "person_name": "Flavio Barcelos Braz Da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 123,
+                "person_name": "Danilo De Paula E Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1099,
+                "person_name": "Giovani Zanetti Neto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1740,
+                "person_name": "Tiago Malavazi de Christo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-24T00:00:00"
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-10-05T00:00:00"
+            },
+            {
+                "person_id": 1742,
+                "person_name": "Dárcio Leitão Quintas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1743,
+                "person_name": "Felipe Morilho de Castro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1744,
+                "person_name": "Guilherme Lima Barbarioli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 4716,
+                "person_name": "Danilo de Paula e Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4717,
+                "person_name": "Edmilson Bermudes Rocha Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2851,
+                "person_name": "João Vitor Ferreira Duque",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4718,
+                "person_name": "Jussara Farias Fardin",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4719,
+                "person_name": "Renato Tannure Rotta de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-10-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4720,
+                "person_name": "Renner Sartório Camargo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-03-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1658,
+                "person_name": "Vinícius Secchin de Melo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-11-19T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 123,
                 "person_name": "Danilo De Paula E Silva",
@@ -1122,7 +3365,11 @@
                 "start_date": "2023-11-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 90,
+            "name": "Grupo de Energias Renováveis para Automação"
+        }
     },
     {
         "id": 10,
@@ -1209,7 +3456,8 @@
                 "start_date": "2024-03-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 11,
@@ -1287,7 +3535,8 @@
                 "start_date": "2024-03-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 12,
@@ -1310,6 +3559,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 117,
                 "person_name": "Gustavo Maia De Almeida",
@@ -1347,7 +3776,11 @@
                 "start_date": "2024-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 13,
@@ -1370,6 +3803,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4715,
                 "person_name": "Rogério Passos do Amaral Pereira",
@@ -1426,7 +4039,11 @@
                 "start_date": "2024-04-09T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 14,
@@ -1540,7 +4157,8 @@
                 "start_date": "2024-07-31T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 15,
@@ -1591,7 +4209,8 @@
                 "start_date": "2024-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 16,
@@ -1614,6 +4233,177 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 141,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 142,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-22T00:00:00",
+                "end_date": "2024-10-15T00:00:00"
+            },
+            {
+                "person_id": 1993,
+                "person_name": "Enzo Mandelli Pinheiro Rodrigues",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1994,
+                "person_name": "Ícaro Lessa Secchin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1995,
+                "person_name": "Johnny Anjos Alves Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-10T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1997,
+                "person_name": "Leandro Everton Alves Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1998,
+                "person_name": "Letícia Comissário da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-10T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2000,
+                "person_name": "Pedro Daniel Trigueiro Bilé",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2001,
+                "person_name": "Rara Perozini Barroca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4721,
+                "person_name": "Marcelo Queiroz Schimidt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4722,
+                "person_name": "Marcos Simão Guimarães",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-04-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3182,
+                "person_name": "Tatiane Policário Chagas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-26T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4723,
+                "person_name": "Wagner Scopel Falcão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-26T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3728,
                 "person_name": "Gabriel Tozatto Zago",
@@ -1642,7 +4432,11 @@
                 "start_date": "2024-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 104,
+            "name": "Grupo de Estudo em Tecnologia, Ensino e Cultura Maker"
+        }
     },
     {
         "id": 17,
@@ -1729,7 +4523,8 @@
                 "start_date": "2024-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 18,
@@ -1834,7 +4629,8 @@
                 "start_date": "2024-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 19,
@@ -1894,7 +4690,8 @@
                 "start_date": "2024-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 20,
@@ -1917,6 +4714,564 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 290,
+                "person_name": "Hilário Tomaz Alves De Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 291,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3213,
+                "person_name": "Ernani Leite Ribeiro Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3214,
+                "person_name": "Fabiano Borges Ruy",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-29T00:00:00",
+                "end_date": "2023-04-03T00:00:00"
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-09-25T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3218,
+                "person_name": "Ronaldo Aparecida Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 3220,
+                "person_name": "Antonio Ricardo Alexandre Brasil",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3221,
+                "person_name": "Gustavo Grimaldi Campello",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3222,
+                "person_name": "Hanna Tátila de Sousa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3223,
+                "person_name": "João Carlos Pandolfi Santana",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3224,
+                "person_name": "Lucas Dipré Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3225,
+                "person_name": "Pedro Henrique Borges Lopes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3226,
+                "person_name": "Rafael Broédel Pedroni",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3227,
+                "person_name": "Thanner Soares Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3228,
+                "person_name": "Victor Gonçalves Valfré",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-09-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4733,
+                "person_name": "Filipe Wall Mutz",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4734,
+                "person_name": "Hilário Tomaz Alves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4735,
+                "person_name": "Mateus Conrad Barcellos da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4736,
+                "person_name": "Rodrigo Fernandes Calhau",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4737,
+                "person_name": "Aline dos Santos Laranja Vileforte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4738,
+                "person_name": "Alvaro Vinicius de Almeida Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4739,
+                "person_name": "André Boechat Felipe",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4740,
+                "person_name": "Arthur Chisté Lucas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4741,
+                "person_name": "Arthur Corona Pimentel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4742,
+                "person_name": "Arthur Rafael Vital Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4743,
+                "person_name": "Calebe Ferreira Albertino",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4744,
+                "person_name": "Cleber de Jesus Salustiano",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4745,
+                "person_name": "Dafne Fernandes Piovesan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4746,
+                "person_name": "Daniel Folador Rossi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4747,
+                "person_name": "Danilo Xavier Valle",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4748,
+                "person_name": "Eliza Karyn dos Santos de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4749,
+                "person_name": "Erick Machado Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4750,
+                "person_name": "Fabio Bermudes Cabral",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-04-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4751,
+                "person_name": "Filipe Anunciação Batista de Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4752,
+                "person_name": "Gabriel Mota Bromonschenkel Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4753,
+                "person_name": "Gean Paulo Oliveira Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4754,
+                "person_name": "Gustavo Firme Fiorot",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4755,
+                "person_name": "Ilanna dos Reis Cardoso",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4756,
+                "person_name": "Jean Carlos Penas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4757,
+                "person_name": "Jhovany Paulo Schelemberg Murgia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4758,
+                "person_name": "João Victor Berti Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4759,
+                "person_name": "Leandro Baêta Lustosa Pontes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4760,
+                "person_name": "Luís Felippe Coutinho de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4761,
+                "person_name": "Matheus Oliveira Jagi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4762,
+                "person_name": "Messias Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4763,
+                "person_name": "Pablo Matheus Sattamini Belmiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4764,
+                "person_name": "Pâmella Gonçalves Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4765,
+                "person_name": "Pedro Mariani Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4766,
+                "person_name": "Rafael Depollo Vassena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4499,
+                "person_name": "Renato Santos Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4767,
+                "person_name": "Tiago Felipe Vivaldi Braga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4768,
+                "person_name": "Victor Samuel Batista Alvarenga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4769,
+                "person_name": "Vinícius Reinholz de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4735,
                 "person_name": "Mateus Conrad Barcellos da Costa",
@@ -1999,7 +5354,11 @@
                 "start_date": "2024-11-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 212,
+            "name": "Laboratório de Inteligência Computacional e Sistemas de informação"
+        }
     },
     {
         "id": 21,
@@ -2022,6 +5381,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1659,
                 "person_name": "Dirceu Soares Júnior",
@@ -2086,7 +5625,11 @@
                 "start_date": "2025-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 22,
@@ -2109,6 +5652,213 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 122,
+                "person_name": "Flavio Barcelos Braz Da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 123,
+                "person_name": "Danilo De Paula E Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1099,
+                "person_name": "Giovani Zanetti Neto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1740,
+                "person_name": "Tiago Malavazi de Christo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-24T00:00:00"
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-10-05T00:00:00"
+            },
+            {
+                "person_id": 1742,
+                "person_name": "Dárcio Leitão Quintas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1743,
+                "person_name": "Felipe Morilho de Castro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1744,
+                "person_name": "Guilherme Lima Barbarioli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 4716,
+                "person_name": "Danilo de Paula e Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4717,
+                "person_name": "Edmilson Bermudes Rocha Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2851,
+                "person_name": "João Vitor Ferreira Duque",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4718,
+                "person_name": "Jussara Farias Fardin",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4719,
+                "person_name": "Renato Tannure Rotta de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-10-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4720,
+                "person_name": "Renner Sartório Camargo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-03-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1658,
+                "person_name": "Vinícius Secchin de Melo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-11-19T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 123,
                 "person_name": "Danilo De Paula E Silva",
@@ -2335,7 +6085,11 @@
                 "start_date": "2024-12-23T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 90,
+            "name": "Grupo de Energias Renováveis para Automação"
+        }
     },
     {
         "id": 23,
@@ -2358,6 +6112,168 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 64,
+                "person_name": "Maikon Chaider Silva Scaldaferro",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1312,
+                "person_name": "Renato Pereira Aurélio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-25T00:00:00",
+                "end_date": "2025-12-04T00:00:00"
+            },
+            {
+                "person_id": 1313,
+                "person_name": "Tiago Dallapiccola",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2025-12-04T00:00:00"
+            },
+            {
+                "person_id": 1314,
+                "person_name": "Ana Carolina Moura Marques",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-05-25T00:00:00",
+                "end_date": "2025-12-04T00:00:00"
+            },
+            {
+                "person_id": 1315,
+                "person_name": "Douglas Mello de Almeida",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-04-12T00:00:00",
+                "end_date": "2025-12-04T00:00:00"
+            },
+            {
+                "person_id": 1316,
+                "person_name": "Eloiza Rocha Barros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-04-12T00:00:00",
+                "end_date": "2025-12-04T00:00:00"
+            },
+            {
+                "person_id": 1317,
+                "person_name": "Gabriel Sossai Pancieri",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-05-25T00:00:00",
+                "end_date": "2025-12-04T00:00:00"
+            },
+            {
+                "person_id": 4701,
+                "person_name": "Adilson Silva Santos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4702,
+                "person_name": "Fábio Boscaglia Pinto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-04-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4703,
+                "person_name": "Maikon Chaider Silva Scaldaferro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3185,
+                "person_name": "Marcelo Mendonça Vieira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4704,
+                "person_name": "Márcio De Paula Filgueiras",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4454,
+                "person_name": "Regina de Marchi Lyra Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2291,
+                "person_name": "Sâmela Pedrada Cardoso",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-08-03T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4705,
+                "person_name": "Esthefani Pereira Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-05-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4706,
+                "person_name": "Iasmin Nunes Gonçalves de Sá",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-05-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4707,
+                "person_name": "Kevin Bravim Rezende",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-04-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4708,
+                "person_name": "Melissa Damacena da Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-05-25T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4703,
                 "person_name": "Maikon Chaider Silva Scaldaferro",
@@ -2386,7 +6302,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 50,
+            "name": "Educação, trabalho, cultura e organizações: estudos interdisciplinares"
+        }
     },
     {
         "id": 24,
@@ -2409,6 +6329,1140 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 351,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 352,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3723,
+                "person_name": "Avelino Forechi Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-25T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3725,
+                "person_name": "Felipe Nascimento Martins",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-10T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 2415,
+                "person_name": "Hudson Cassio Gomes de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3729,
+                "person_name": "Rafael Peixoto Derenzi Vivacqua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3730,
+                "person_name": "Reginaldo Corteletti",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-14T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3731,
+                "person_name": "Teodiano Freire Bastos Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-10T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3733,
+                "person_name": "Adjuto Martins Vasconcelos Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3734,
+                "person_name": "Akilanny Silva Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3735,
+                "person_name": "Alan Pablo Donati Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3736,
+                "person_name": "Allicia Rocha dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3737,
+                "person_name": "Alter DIego do Nascimento Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3738,
+                "person_name": "Álvaro Soldani Gondim de Freitas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3739,
+                "person_name": "Amanda Balestreiro Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3740,
+                "person_name": "Amanda Frasson Nascimento Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-12-15T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3741,
+                "person_name": "Ana Carolina Ichimura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3742,
+                "person_name": "Ana Carolina Ichimura Bermudes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3743,
+                "person_name": "Ana Luiza Alves da Silva do Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3744,
+                "person_name": "Ana Paula Costa de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3745,
+                "person_name": "Andre Barbosa da Vitoria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3746,
+                "person_name": "Bárbara Fábri Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3747,
+                "person_name": "Bruna Heringer Xavier",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3748,
+                "person_name": "Bruno Meschiatti Vasconcellos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3749,
+                "person_name": "Bruno Rocha Pratti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3750,
+                "person_name": "Carlos Eduardo Gomes Reddo Alves",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3751,
+                "person_name": "Carlos Henrique Gomes Correia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3752,
+                "person_name": "Cecilia Tavares Barreto",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3753,
+                "person_name": "Claudio Leandro Nascimento Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-25T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3754,
+                "person_name": "Cleiton Máximo Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3755,
+                "person_name": "Danilo da Silva Alvarez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-08T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3756,
+                "person_name": "Debora Galavote Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3757,
+                "person_name": "Diego Luchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3758,
+                "person_name": "Eduarda Assis de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3759,
+                "person_name": "Eduardo de Oliveira Pereira Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3760,
+                "person_name": "Eliabe de Assis Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3761,
+                "person_name": "Elisa De Pinho Pires Marinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3762,
+                "person_name": "Enthoni Araujo Fontis Serafim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3763,
+                "person_name": "Enzo Medeiros Agnez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3764,
+                "person_name": "Erick Kenzo Komati",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3765,
+                "person_name": "Estevão Nolasco Fonseca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3766,
+                "person_name": "Fábio Pinto Monte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3767,
+                "person_name": "Filipe Suhett Nogueira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3768,
+                "person_name": "Flávio Fonsêca de Mendonça",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3769,
+                "person_name": "Frederico Arleu Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3770,
+                "person_name": "Gabriel Saade Pagani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-03-19T00:00:00"
+            },
+            {
+                "person_id": 3771,
+                "person_name": "Guilherme Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3772,
+                "person_name": "Gustavo Amora Basílio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3774,
+                "person_name": "Heitor Libardi Bezerra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3775,
+                "person_name": "Israel de Morais Madalena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-10-14T00:00:00"
+            },
+            {
+                "person_id": 3776,
+                "person_name": "Israel Magalhães do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3777,
+                "person_name": "Jéssica Vieira Alvarenga dos Passos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3778,
+                "person_name": "João Paulo Gusmão Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3779,
+                "person_name": "João Victor Ferreira Abrêu",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2023-12-15T00:00:00"
+            },
+            {
+                "person_id": 3780,
+                "person_name": "João Vitor Silveira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3781,
+                "person_name": "Julia Sagrillo Barreiros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3782,
+                "person_name": "Kamila Maria Vieira Pralon",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3783,
+                "person_name": "Klara Matos Gazoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3784,
+                "person_name": "Luca da Gama Wyatt",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3785,
+                "person_name": "Lucas Rigo Tofoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3786,
+                "person_name": "Lucio Antonio Stange Venturim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3787,
+                "person_name": "Ludmila Dias",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3012,
+                "person_name": "Luiz Soneghet Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-11-04T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3181,
+                "person_name": "Magnu Windell Araújo Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2021-02-23T00:00:00"
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3789,
+                "person_name": "Marlon de Oliveira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3790,
+                "person_name": "Marlon Woelffel Candoti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-10-02T00:00:00"
+            },
+            {
+                "person_id": 3791,
+                "person_name": "Mateus Emanuel Mamani Araujo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-03T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3792,
+                "person_name": "Matheus de Araujo Nogueira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2021-12-06T00:00:00"
+            },
+            {
+                "person_id": 3793,
+                "person_name": "Matheus Inácio Silva Mol",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3794,
+                "person_name": "Mayannara Trindade Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3795,
+                "person_name": "Miguel Gonçalves Schroeffer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3796,
+                "person_name": "Nicoly Ferreira dos Santos Pazini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": "2025-12-18T00:00:00"
+            },
+            {
+                "person_id": 3797,
+                "person_name": "Raphael Rebello Haddad",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3798,
+                "person_name": "Rodrigo Gomes Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3799,
+                "person_name": "Rodrigo Piol Capucho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3800,
+                "person_name": "Sandy Keury Matos Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3801,
+                "person_name": "Sérgio Daniel Camponez Leal",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3802,
+                "person_name": "Thaís da Silva Ferrarini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3803,
+                "person_name": "Thiago Almeida deps Caldeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3805,
+                "person_name": "Thiago de Oliveira Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-08-23T00:00:00"
+            },
+            {
+                "person_id": 3806,
+                "person_name": "Vitor do Nascimento Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3807,
+                "person_name": "Walter Adriani Gazolli Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3808,
+                "person_name": "Yasmim Alessa Paulino Romero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 4770,
+                "person_name": "Adriano Marcio Sgrancio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-06-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1198,
+                "person_name": "Leonardo Aguiar do Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4771,
+                "person_name": "Leonardo Azevedo Scardua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4772,
+                "person_name": "Marcos Paulo Kohler Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-06T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-05-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4773,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4774,
+                "person_name": "Amanda Paiva de Souza Silveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4775,
+                "person_name": "Ana Clara Dalvin Del Piero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4776,
+                "person_name": "Analice Clarindo Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4777,
+                "person_name": "Arthur Fabrício Da Silva Pires de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4778,
+                "person_name": "David de Assis",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4779,
+                "person_name": "Iago Moraes De Marchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4780,
+                "person_name": "Joaquim Estefan Vivas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4781,
+                "person_name": "Kauã Alexandre Bernardes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4782,
+                "person_name": "Lavínia Lima Rodrigues da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4783,
+                "person_name": "Lucas Amorim Silva Gois",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4784,
+                "person_name": "Lucas Stefanelli Vieira Stefanelli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4785,
+                "person_name": "Lucca Richa Campagnoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4786,
+                "person_name": "Luma Tavares Lopes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4787,
+                "person_name": "Maria Clara De Moura E Silva Barcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4788,
+                "person_name": "Maria Clara Peterle de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-02-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4789,
+                "person_name": "Myllena Furtado Toniato",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4790,
+                "person_name": "Pedro Henrique Albani Nunes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4791,
+                "person_name": "Raíssa Andrade Dutra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4792,
+                "person_name": "Rian Dezan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4793,
+                "person_name": "Sofia Alves FIgueredo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4794,
+                "person_name": "Tertuliano dos Santos Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4795,
+                "person_name": "Valentina Sobral Endringer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4796,
+                "person_name": "Victória Da Silva Maciel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4797,
+                "person_name": "Wallace da Costa Ferreira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3216,
                 "person_name": "Marta Talitha Carvalho Freire Mendes",
@@ -2455,7 +7509,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 256,
+            "name": "Núcleo de Estudos em Robótica e Automação"
+        }
     },
     {
         "id": 25,
@@ -2560,7 +7618,8 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 26,
@@ -2583,6 +7642,168 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 250,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 251,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-04-01T00:00:00",
+                "end_date": "2025-03-20T00:00:00"
+            },
+            {
+                "person_id": 2782,
+                "person_name": "Cleber Silva Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": "2021-12-18T00:00:00"
+            },
+            {
+                "person_id": 2783,
+                "person_name": "Giancarlo Oliveira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-07T00:00:00"
+            },
+            {
+                "person_id": 2784,
+                "person_name": "Harrison Felipe Sanches Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-12-18T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4724,
+                "person_name": "Fábio de Oliveira Lima",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4725,
+                "person_name": "Gilmar Luiz Vassoler",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4726,
+                "person_name": "Adailton Saraiva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1569,
+                "person_name": "Alan Pancieri Berger Saar",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4727,
+                "person_name": "Ana Júlia Caetano Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4728,
+                "person_name": "Bruno Moreto de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4729,
+                "person_name": "Eduarda Nascimento Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4730,
+                "person_name": "Jeorge Terci Gasperazzo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4731,
+                "person_name": "Leonardo Zuchi Guio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3813,
                 "person_name": "Leandro Colombi Resendo",
@@ -2611,7 +7832,11 @@
                 "start_date": "2025-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 178,
+            "name": "Grupo de Pesquisa em Redes e Otimização"
+        }
     },
     {
         "id": 27,
@@ -2634,6 +7859,564 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 290,
+                "person_name": "Hilário Tomaz Alves De Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 291,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3213,
+                "person_name": "Ernani Leite Ribeiro Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3214,
+                "person_name": "Fabiano Borges Ruy",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-29T00:00:00",
+                "end_date": "2023-04-03T00:00:00"
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-09-25T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3218,
+                "person_name": "Ronaldo Aparecida Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 3220,
+                "person_name": "Antonio Ricardo Alexandre Brasil",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3221,
+                "person_name": "Gustavo Grimaldi Campello",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3222,
+                "person_name": "Hanna Tátila de Sousa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3223,
+                "person_name": "João Carlos Pandolfi Santana",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3224,
+                "person_name": "Lucas Dipré Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3225,
+                "person_name": "Pedro Henrique Borges Lopes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3226,
+                "person_name": "Rafael Broédel Pedroni",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3227,
+                "person_name": "Thanner Soares Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3228,
+                "person_name": "Victor Gonçalves Valfré",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-09-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4733,
+                "person_name": "Filipe Wall Mutz",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4734,
+                "person_name": "Hilário Tomaz Alves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4735,
+                "person_name": "Mateus Conrad Barcellos da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4736,
+                "person_name": "Rodrigo Fernandes Calhau",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4737,
+                "person_name": "Aline dos Santos Laranja Vileforte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4738,
+                "person_name": "Alvaro Vinicius de Almeida Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4739,
+                "person_name": "André Boechat Felipe",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4740,
+                "person_name": "Arthur Chisté Lucas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4741,
+                "person_name": "Arthur Corona Pimentel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4742,
+                "person_name": "Arthur Rafael Vital Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4743,
+                "person_name": "Calebe Ferreira Albertino",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4744,
+                "person_name": "Cleber de Jesus Salustiano",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4745,
+                "person_name": "Dafne Fernandes Piovesan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4746,
+                "person_name": "Daniel Folador Rossi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4747,
+                "person_name": "Danilo Xavier Valle",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4748,
+                "person_name": "Eliza Karyn dos Santos de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4749,
+                "person_name": "Erick Machado Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4750,
+                "person_name": "Fabio Bermudes Cabral",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-04-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4751,
+                "person_name": "Filipe Anunciação Batista de Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4752,
+                "person_name": "Gabriel Mota Bromonschenkel Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4753,
+                "person_name": "Gean Paulo Oliveira Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4754,
+                "person_name": "Gustavo Firme Fiorot",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4755,
+                "person_name": "Ilanna dos Reis Cardoso",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4756,
+                "person_name": "Jean Carlos Penas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4757,
+                "person_name": "Jhovany Paulo Schelemberg Murgia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4758,
+                "person_name": "João Victor Berti Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4759,
+                "person_name": "Leandro Baêta Lustosa Pontes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4760,
+                "person_name": "Luís Felippe Coutinho de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4761,
+                "person_name": "Matheus Oliveira Jagi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4762,
+                "person_name": "Messias Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4763,
+                "person_name": "Pablo Matheus Sattamini Belmiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4764,
+                "person_name": "Pâmella Gonçalves Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4765,
+                "person_name": "Pedro Mariani Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4766,
+                "person_name": "Rafael Depollo Vassena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4499,
+                "person_name": "Renato Santos Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4767,
+                "person_name": "Tiago Felipe Vivaldi Braga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4768,
+                "person_name": "Victor Samuel Batista Alvarenga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4769,
+                "person_name": "Vinícius Reinholz de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3727,
                 "person_name": "Francisco de Assis Boldt",
@@ -2689,7 +8472,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 212,
+            "name": "Laboratório de Inteligência Computacional e Sistemas de informação"
+        }
     },
     {
         "id": 28,
@@ -2712,6 +8499,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4715,
                 "person_name": "Rogério Passos do Amaral Pereira",
@@ -2795,7 +8762,11 @@
                 "start_date": "2025-04-05T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 29,
@@ -2818,6 +8789,177 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 141,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 142,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-22T00:00:00",
+                "end_date": "2024-10-15T00:00:00"
+            },
+            {
+                "person_id": 1993,
+                "person_name": "Enzo Mandelli Pinheiro Rodrigues",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1994,
+                "person_name": "Ícaro Lessa Secchin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1995,
+                "person_name": "Johnny Anjos Alves Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-10T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1997,
+                "person_name": "Leandro Everton Alves Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1998,
+                "person_name": "Letícia Comissário da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-10T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2000,
+                "person_name": "Pedro Daniel Trigueiro Bilé",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2001,
+                "person_name": "Rara Perozini Barroca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4721,
+                "person_name": "Marcelo Queiroz Schimidt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4722,
+                "person_name": "Marcos Simão Guimarães",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-04-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3182,
+                "person_name": "Tatiane Policário Chagas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-26T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4723,
+                "person_name": "Wagner Scopel Falcão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-26T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3728,
                 "person_name": "Gabriel Tozatto Zago",
@@ -2846,7 +8988,11 @@
                 "start_date": "2025-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 104,
+            "name": "Grupo de Estudo em Tecnologia, Ensino e Cultura Maker"
+        }
     },
     {
         "id": 30,
@@ -2869,6 +9015,213 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 122,
+                "person_name": "Flavio Barcelos Braz Da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 123,
+                "person_name": "Danilo De Paula E Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1099,
+                "person_name": "Giovani Zanetti Neto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1740,
+                "person_name": "Tiago Malavazi de Christo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-24T00:00:00"
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-10-05T00:00:00"
+            },
+            {
+                "person_id": 1742,
+                "person_name": "Dárcio Leitão Quintas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1743,
+                "person_name": "Felipe Morilho de Castro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1744,
+                "person_name": "Guilherme Lima Barbarioli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 4716,
+                "person_name": "Danilo de Paula e Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4717,
+                "person_name": "Edmilson Bermudes Rocha Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2851,
+                "person_name": "João Vitor Ferreira Duque",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4718,
+                "person_name": "Jussara Farias Fardin",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4719,
+                "person_name": "Renato Tannure Rotta de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-10-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4720,
+                "person_name": "Renner Sartório Camargo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-03-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1658,
+                "person_name": "Vinícius Secchin de Melo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-11-19T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 123,
                 "person_name": "Danilo De Paula E Silva",
@@ -3014,7 +9367,11 @@
                 "start_date": "2025-04-10T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 90,
+            "name": "Grupo de Energias Renováveis para Automação"
+        }
     },
     {
         "id": 31,
@@ -3037,6 +9394,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 117,
                 "person_name": "Gustavo Maia De Almeida",
@@ -3074,7 +9611,11 @@
                 "start_date": "2025-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 32,
@@ -3097,6 +9638,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 116,
                 "person_name": "Marco Antonio De Souza Leite Cuadros",
@@ -3143,7 +9864,11 @@
                 "start_date": "2025-05-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 33,
@@ -3166,6 +9891,168 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 250,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 251,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-04-01T00:00:00",
+                "end_date": "2025-03-20T00:00:00"
+            },
+            {
+                "person_id": 2782,
+                "person_name": "Cleber Silva Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": "2021-12-18T00:00:00"
+            },
+            {
+                "person_id": 2783,
+                "person_name": "Giancarlo Oliveira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-07T00:00:00"
+            },
+            {
+                "person_id": 2784,
+                "person_name": "Harrison Felipe Sanches Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-12-18T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4724,
+                "person_name": "Fábio de Oliveira Lima",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4725,
+                "person_name": "Gilmar Luiz Vassoler",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4726,
+                "person_name": "Adailton Saraiva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1569,
+                "person_name": "Alan Pancieri Berger Saar",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4727,
+                "person_name": "Ana Júlia Caetano Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4728,
+                "person_name": "Bruno Moreto de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4729,
+                "person_name": "Eduarda Nascimento Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4730,
+                "person_name": "Jeorge Terci Gasperazzo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4731,
+                "person_name": "Leonardo Zuchi Guio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3810,
                 "person_name": "Cristina Klippel Dominicini",
@@ -3257,7 +10144,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 178,
+            "name": "Grupo de Pesquisa em Redes e Otimização"
+        }
     },
     {
         "id": 34,
@@ -3280,6 +10171,222 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 114,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 115,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-08-09T00:00:00",
+                "end_date": "2024-10-22T00:00:00"
+            },
+            {
+                "person_id": 1660,
+                "person_name": "Rodrigo Altoé",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-03-10T00:00:00"
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-26T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1663,
+                "person_name": "Douglas Souza Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1664,
+                "person_name": "Enzo Salamão Roseiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1665,
+                "person_name": "Fernanda Mayumi Fukai",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1666,
+                "person_name": "Heidy de Oliveira Simões",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1667,
+                "person_name": "Juliana Dalmaso da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1668,
+                "person_name": "Kessia Klein Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-10-28T00:00:00"
+            },
+            {
+                "person_id": 1669,
+                "person_name": "Marciel Mario Degasperi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1670,
+                "person_name": "Marjorie Ariele Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1671,
+                "person_name": "Matheus Santiago Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-13T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1672,
+                "person_name": "Paulo José de Almeida Barbosa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1673,
+                "person_name": "Renan Oliveira de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1674,
+                "person_name": "Reynan Giacomin Borlini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-12-05T00:00:00"
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4709,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-07-30T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3726,
                 "person_name": "Flávio Garcia Pereira",
@@ -3317,7 +10424,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 85,
+            "name": "Grupo de Aprendizado de Máquina e Automação"
+        }
     },
     {
         "id": 35,
@@ -3340,6 +10451,222 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 114,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 115,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-08-09T00:00:00",
+                "end_date": "2024-10-22T00:00:00"
+            },
+            {
+                "person_id": 1660,
+                "person_name": "Rodrigo Altoé",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-03-10T00:00:00"
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-26T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1663,
+                "person_name": "Douglas Souza Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1664,
+                "person_name": "Enzo Salamão Roseiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1665,
+                "person_name": "Fernanda Mayumi Fukai",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1666,
+                "person_name": "Heidy de Oliveira Simões",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1667,
+                "person_name": "Juliana Dalmaso da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1668,
+                "person_name": "Kessia Klein Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-10-28T00:00:00"
+            },
+            {
+                "person_id": 1669,
+                "person_name": "Marciel Mario Degasperi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1670,
+                "person_name": "Marjorie Ariele Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1671,
+                "person_name": "Matheus Santiago Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-13T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1672,
+                "person_name": "Paulo José de Almeida Barbosa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1673,
+                "person_name": "Renan Oliveira de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1674,
+                "person_name": "Reynan Giacomin Borlini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-12-05T00:00:00"
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4709,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-07-30T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4709,
                 "person_name": "Luiz Alberto Pinto",
@@ -3377,7 +10704,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 85,
+            "name": "Grupo de Aprendizado de Máquina e Automação"
+        }
     },
     {
         "id": 36,
@@ -3400,6 +10731,1140 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 351,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 352,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3723,
+                "person_name": "Avelino Forechi Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-25T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3725,
+                "person_name": "Felipe Nascimento Martins",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-10T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 2415,
+                "person_name": "Hudson Cassio Gomes de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3729,
+                "person_name": "Rafael Peixoto Derenzi Vivacqua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3730,
+                "person_name": "Reginaldo Corteletti",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-14T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3731,
+                "person_name": "Teodiano Freire Bastos Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-10T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3733,
+                "person_name": "Adjuto Martins Vasconcelos Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3734,
+                "person_name": "Akilanny Silva Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3735,
+                "person_name": "Alan Pablo Donati Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3736,
+                "person_name": "Allicia Rocha dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3737,
+                "person_name": "Alter DIego do Nascimento Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3738,
+                "person_name": "Álvaro Soldani Gondim de Freitas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3739,
+                "person_name": "Amanda Balestreiro Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3740,
+                "person_name": "Amanda Frasson Nascimento Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-12-15T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3741,
+                "person_name": "Ana Carolina Ichimura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3742,
+                "person_name": "Ana Carolina Ichimura Bermudes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3743,
+                "person_name": "Ana Luiza Alves da Silva do Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3744,
+                "person_name": "Ana Paula Costa de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3745,
+                "person_name": "Andre Barbosa da Vitoria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3746,
+                "person_name": "Bárbara Fábri Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3747,
+                "person_name": "Bruna Heringer Xavier",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3748,
+                "person_name": "Bruno Meschiatti Vasconcellos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3749,
+                "person_name": "Bruno Rocha Pratti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3750,
+                "person_name": "Carlos Eduardo Gomes Reddo Alves",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3751,
+                "person_name": "Carlos Henrique Gomes Correia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3752,
+                "person_name": "Cecilia Tavares Barreto",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3753,
+                "person_name": "Claudio Leandro Nascimento Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-25T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3754,
+                "person_name": "Cleiton Máximo Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3755,
+                "person_name": "Danilo da Silva Alvarez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-08T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3756,
+                "person_name": "Debora Galavote Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3757,
+                "person_name": "Diego Luchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3758,
+                "person_name": "Eduarda Assis de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3759,
+                "person_name": "Eduardo de Oliveira Pereira Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3760,
+                "person_name": "Eliabe de Assis Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3761,
+                "person_name": "Elisa De Pinho Pires Marinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3762,
+                "person_name": "Enthoni Araujo Fontis Serafim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3763,
+                "person_name": "Enzo Medeiros Agnez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3764,
+                "person_name": "Erick Kenzo Komati",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3765,
+                "person_name": "Estevão Nolasco Fonseca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3766,
+                "person_name": "Fábio Pinto Monte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3767,
+                "person_name": "Filipe Suhett Nogueira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3768,
+                "person_name": "Flávio Fonsêca de Mendonça",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3769,
+                "person_name": "Frederico Arleu Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3770,
+                "person_name": "Gabriel Saade Pagani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-03-19T00:00:00"
+            },
+            {
+                "person_id": 3771,
+                "person_name": "Guilherme Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3772,
+                "person_name": "Gustavo Amora Basílio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3774,
+                "person_name": "Heitor Libardi Bezerra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3775,
+                "person_name": "Israel de Morais Madalena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-10-14T00:00:00"
+            },
+            {
+                "person_id": 3776,
+                "person_name": "Israel Magalhães do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3777,
+                "person_name": "Jéssica Vieira Alvarenga dos Passos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3778,
+                "person_name": "João Paulo Gusmão Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3779,
+                "person_name": "João Victor Ferreira Abrêu",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2023-12-15T00:00:00"
+            },
+            {
+                "person_id": 3780,
+                "person_name": "João Vitor Silveira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3781,
+                "person_name": "Julia Sagrillo Barreiros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3782,
+                "person_name": "Kamila Maria Vieira Pralon",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3783,
+                "person_name": "Klara Matos Gazoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3784,
+                "person_name": "Luca da Gama Wyatt",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3785,
+                "person_name": "Lucas Rigo Tofoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3786,
+                "person_name": "Lucio Antonio Stange Venturim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3787,
+                "person_name": "Ludmila Dias",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3012,
+                "person_name": "Luiz Soneghet Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-11-04T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3181,
+                "person_name": "Magnu Windell Araújo Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2021-02-23T00:00:00"
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3789,
+                "person_name": "Marlon de Oliveira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3790,
+                "person_name": "Marlon Woelffel Candoti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-10-02T00:00:00"
+            },
+            {
+                "person_id": 3791,
+                "person_name": "Mateus Emanuel Mamani Araujo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-03T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3792,
+                "person_name": "Matheus de Araujo Nogueira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2021-12-06T00:00:00"
+            },
+            {
+                "person_id": 3793,
+                "person_name": "Matheus Inácio Silva Mol",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3794,
+                "person_name": "Mayannara Trindade Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3795,
+                "person_name": "Miguel Gonçalves Schroeffer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3796,
+                "person_name": "Nicoly Ferreira dos Santos Pazini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": "2025-12-18T00:00:00"
+            },
+            {
+                "person_id": 3797,
+                "person_name": "Raphael Rebello Haddad",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3798,
+                "person_name": "Rodrigo Gomes Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3799,
+                "person_name": "Rodrigo Piol Capucho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3800,
+                "person_name": "Sandy Keury Matos Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3801,
+                "person_name": "Sérgio Daniel Camponez Leal",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3802,
+                "person_name": "Thaís da Silva Ferrarini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3803,
+                "person_name": "Thiago Almeida deps Caldeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3805,
+                "person_name": "Thiago de Oliveira Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-08-23T00:00:00"
+            },
+            {
+                "person_id": 3806,
+                "person_name": "Vitor do Nascimento Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3807,
+                "person_name": "Walter Adriani Gazolli Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3808,
+                "person_name": "Yasmim Alessa Paulino Romero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 4770,
+                "person_name": "Adriano Marcio Sgrancio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-06-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1198,
+                "person_name": "Leonardo Aguiar do Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4771,
+                "person_name": "Leonardo Azevedo Scardua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4772,
+                "person_name": "Marcos Paulo Kohler Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-06T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-05-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4773,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4774,
+                "person_name": "Amanda Paiva de Souza Silveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4775,
+                "person_name": "Ana Clara Dalvin Del Piero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4776,
+                "person_name": "Analice Clarindo Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4777,
+                "person_name": "Arthur Fabrício Da Silva Pires de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4778,
+                "person_name": "David de Assis",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4779,
+                "person_name": "Iago Moraes De Marchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4780,
+                "person_name": "Joaquim Estefan Vivas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4781,
+                "person_name": "Kauã Alexandre Bernardes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4782,
+                "person_name": "Lavínia Lima Rodrigues da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4783,
+                "person_name": "Lucas Amorim Silva Gois",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4784,
+                "person_name": "Lucas Stefanelli Vieira Stefanelli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4785,
+                "person_name": "Lucca Richa Campagnoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4786,
+                "person_name": "Luma Tavares Lopes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4787,
+                "person_name": "Maria Clara De Moura E Silva Barcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4788,
+                "person_name": "Maria Clara Peterle de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-02-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4789,
+                "person_name": "Myllena Furtado Toniato",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4790,
+                "person_name": "Pedro Henrique Albani Nunes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4791,
+                "person_name": "Raíssa Andrade Dutra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4792,
+                "person_name": "Rian Dezan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4793,
+                "person_name": "Sofia Alves FIgueredo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4794,
+                "person_name": "Tertuliano dos Santos Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4795,
+                "person_name": "Valentina Sobral Endringer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4796,
+                "person_name": "Victória Da Silva Maciel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4797,
+                "person_name": "Wallace da Costa Ferreira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4773,
                 "person_name": "Richard Junior Manuel Godinez Tello",
@@ -3455,7 +11920,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 256,
+            "name": "Núcleo de Estudos em Robótica e Automação"
+        }
     },
     {
         "id": 37,
@@ -3478,6 +11947,1140 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 351,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 352,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3723,
+                "person_name": "Avelino Forechi Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-25T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3725,
+                "person_name": "Felipe Nascimento Martins",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-10T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 2415,
+                "person_name": "Hudson Cassio Gomes de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3729,
+                "person_name": "Rafael Peixoto Derenzi Vivacqua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3730,
+                "person_name": "Reginaldo Corteletti",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-14T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3731,
+                "person_name": "Teodiano Freire Bastos Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-10T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3733,
+                "person_name": "Adjuto Martins Vasconcelos Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3734,
+                "person_name": "Akilanny Silva Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3735,
+                "person_name": "Alan Pablo Donati Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3736,
+                "person_name": "Allicia Rocha dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3737,
+                "person_name": "Alter DIego do Nascimento Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3738,
+                "person_name": "Álvaro Soldani Gondim de Freitas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3739,
+                "person_name": "Amanda Balestreiro Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3740,
+                "person_name": "Amanda Frasson Nascimento Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-12-15T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3741,
+                "person_name": "Ana Carolina Ichimura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3742,
+                "person_name": "Ana Carolina Ichimura Bermudes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3743,
+                "person_name": "Ana Luiza Alves da Silva do Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3744,
+                "person_name": "Ana Paula Costa de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3745,
+                "person_name": "Andre Barbosa da Vitoria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3746,
+                "person_name": "Bárbara Fábri Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3747,
+                "person_name": "Bruna Heringer Xavier",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3748,
+                "person_name": "Bruno Meschiatti Vasconcellos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3749,
+                "person_name": "Bruno Rocha Pratti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3750,
+                "person_name": "Carlos Eduardo Gomes Reddo Alves",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3751,
+                "person_name": "Carlos Henrique Gomes Correia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3752,
+                "person_name": "Cecilia Tavares Barreto",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3753,
+                "person_name": "Claudio Leandro Nascimento Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-25T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3754,
+                "person_name": "Cleiton Máximo Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3755,
+                "person_name": "Danilo da Silva Alvarez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-08T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3756,
+                "person_name": "Debora Galavote Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3757,
+                "person_name": "Diego Luchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3758,
+                "person_name": "Eduarda Assis de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3759,
+                "person_name": "Eduardo de Oliveira Pereira Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3760,
+                "person_name": "Eliabe de Assis Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3761,
+                "person_name": "Elisa De Pinho Pires Marinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3762,
+                "person_name": "Enthoni Araujo Fontis Serafim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3763,
+                "person_name": "Enzo Medeiros Agnez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3764,
+                "person_name": "Erick Kenzo Komati",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3765,
+                "person_name": "Estevão Nolasco Fonseca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3766,
+                "person_name": "Fábio Pinto Monte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3767,
+                "person_name": "Filipe Suhett Nogueira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3768,
+                "person_name": "Flávio Fonsêca de Mendonça",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3769,
+                "person_name": "Frederico Arleu Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3770,
+                "person_name": "Gabriel Saade Pagani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-03-19T00:00:00"
+            },
+            {
+                "person_id": 3771,
+                "person_name": "Guilherme Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3772,
+                "person_name": "Gustavo Amora Basílio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3774,
+                "person_name": "Heitor Libardi Bezerra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3775,
+                "person_name": "Israel de Morais Madalena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-10-14T00:00:00"
+            },
+            {
+                "person_id": 3776,
+                "person_name": "Israel Magalhães do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3777,
+                "person_name": "Jéssica Vieira Alvarenga dos Passos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3778,
+                "person_name": "João Paulo Gusmão Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3779,
+                "person_name": "João Victor Ferreira Abrêu",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2023-12-15T00:00:00"
+            },
+            {
+                "person_id": 3780,
+                "person_name": "João Vitor Silveira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3781,
+                "person_name": "Julia Sagrillo Barreiros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3782,
+                "person_name": "Kamila Maria Vieira Pralon",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3783,
+                "person_name": "Klara Matos Gazoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3784,
+                "person_name": "Luca da Gama Wyatt",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3785,
+                "person_name": "Lucas Rigo Tofoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3786,
+                "person_name": "Lucio Antonio Stange Venturim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3787,
+                "person_name": "Ludmila Dias",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3012,
+                "person_name": "Luiz Soneghet Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-11-04T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3181,
+                "person_name": "Magnu Windell Araújo Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2021-02-23T00:00:00"
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3789,
+                "person_name": "Marlon de Oliveira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3790,
+                "person_name": "Marlon Woelffel Candoti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-10-02T00:00:00"
+            },
+            {
+                "person_id": 3791,
+                "person_name": "Mateus Emanuel Mamani Araujo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-03T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3792,
+                "person_name": "Matheus de Araujo Nogueira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2021-12-06T00:00:00"
+            },
+            {
+                "person_id": 3793,
+                "person_name": "Matheus Inácio Silva Mol",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3794,
+                "person_name": "Mayannara Trindade Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3795,
+                "person_name": "Miguel Gonçalves Schroeffer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3796,
+                "person_name": "Nicoly Ferreira dos Santos Pazini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": "2025-12-18T00:00:00"
+            },
+            {
+                "person_id": 3797,
+                "person_name": "Raphael Rebello Haddad",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3798,
+                "person_name": "Rodrigo Gomes Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3799,
+                "person_name": "Rodrigo Piol Capucho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3800,
+                "person_name": "Sandy Keury Matos Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3801,
+                "person_name": "Sérgio Daniel Camponez Leal",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3802,
+                "person_name": "Thaís da Silva Ferrarini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3803,
+                "person_name": "Thiago Almeida deps Caldeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3805,
+                "person_name": "Thiago de Oliveira Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-08-23T00:00:00"
+            },
+            {
+                "person_id": 3806,
+                "person_name": "Vitor do Nascimento Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3807,
+                "person_name": "Walter Adriani Gazolli Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3808,
+                "person_name": "Yasmim Alessa Paulino Romero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 4770,
+                "person_name": "Adriano Marcio Sgrancio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-06-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1198,
+                "person_name": "Leonardo Aguiar do Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4771,
+                "person_name": "Leonardo Azevedo Scardua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4772,
+                "person_name": "Marcos Paulo Kohler Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-06T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-05-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4773,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4774,
+                "person_name": "Amanda Paiva de Souza Silveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4775,
+                "person_name": "Ana Clara Dalvin Del Piero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4776,
+                "person_name": "Analice Clarindo Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4777,
+                "person_name": "Arthur Fabrício Da Silva Pires de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4778,
+                "person_name": "David de Assis",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4779,
+                "person_name": "Iago Moraes De Marchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4780,
+                "person_name": "Joaquim Estefan Vivas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4781,
+                "person_name": "Kauã Alexandre Bernardes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4782,
+                "person_name": "Lavínia Lima Rodrigues da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4783,
+                "person_name": "Lucas Amorim Silva Gois",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4784,
+                "person_name": "Lucas Stefanelli Vieira Stefanelli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4785,
+                "person_name": "Lucca Richa Campagnoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4786,
+                "person_name": "Luma Tavares Lopes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4787,
+                "person_name": "Maria Clara De Moura E Silva Barcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4788,
+                "person_name": "Maria Clara Peterle de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-02-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4789,
+                "person_name": "Myllena Furtado Toniato",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4790,
+                "person_name": "Pedro Henrique Albani Nunes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4791,
+                "person_name": "Raíssa Andrade Dutra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4792,
+                "person_name": "Rian Dezan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4793,
+                "person_name": "Sofia Alves FIgueredo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4794,
+                "person_name": "Tertuliano dos Santos Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4795,
+                "person_name": "Valentina Sobral Endringer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4796,
+                "person_name": "Victória Da Silva Maciel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4797,
+                "person_name": "Wallace da Costa Ferreira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4773,
                 "person_name": "Richard Junior Manuel Godinez Tello",
@@ -3524,7 +13127,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 256,
+            "name": "Núcleo de Estudos em Robótica e Automação"
+        }
     },
     {
         "id": 38,
@@ -3547,6 +13154,564 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 290,
+                "person_name": "Hilário Tomaz Alves De Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 291,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3213,
+                "person_name": "Ernani Leite Ribeiro Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3214,
+                "person_name": "Fabiano Borges Ruy",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-29T00:00:00",
+                "end_date": "2023-04-03T00:00:00"
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-09-25T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3218,
+                "person_name": "Ronaldo Aparecida Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 3220,
+                "person_name": "Antonio Ricardo Alexandre Brasil",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3221,
+                "person_name": "Gustavo Grimaldi Campello",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3222,
+                "person_name": "Hanna Tátila de Sousa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3223,
+                "person_name": "João Carlos Pandolfi Santana",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3224,
+                "person_name": "Lucas Dipré Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3225,
+                "person_name": "Pedro Henrique Borges Lopes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3226,
+                "person_name": "Rafael Broédel Pedroni",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3227,
+                "person_name": "Thanner Soares Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3228,
+                "person_name": "Victor Gonçalves Valfré",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-09-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4733,
+                "person_name": "Filipe Wall Mutz",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4734,
+                "person_name": "Hilário Tomaz Alves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4735,
+                "person_name": "Mateus Conrad Barcellos da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4736,
+                "person_name": "Rodrigo Fernandes Calhau",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4737,
+                "person_name": "Aline dos Santos Laranja Vileforte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4738,
+                "person_name": "Alvaro Vinicius de Almeida Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4739,
+                "person_name": "André Boechat Felipe",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4740,
+                "person_name": "Arthur Chisté Lucas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4741,
+                "person_name": "Arthur Corona Pimentel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4742,
+                "person_name": "Arthur Rafael Vital Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4743,
+                "person_name": "Calebe Ferreira Albertino",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4744,
+                "person_name": "Cleber de Jesus Salustiano",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4745,
+                "person_name": "Dafne Fernandes Piovesan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4746,
+                "person_name": "Daniel Folador Rossi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4747,
+                "person_name": "Danilo Xavier Valle",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4748,
+                "person_name": "Eliza Karyn dos Santos de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4749,
+                "person_name": "Erick Machado Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4750,
+                "person_name": "Fabio Bermudes Cabral",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-04-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4751,
+                "person_name": "Filipe Anunciação Batista de Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4752,
+                "person_name": "Gabriel Mota Bromonschenkel Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4753,
+                "person_name": "Gean Paulo Oliveira Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4754,
+                "person_name": "Gustavo Firme Fiorot",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4755,
+                "person_name": "Ilanna dos Reis Cardoso",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4756,
+                "person_name": "Jean Carlos Penas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4757,
+                "person_name": "Jhovany Paulo Schelemberg Murgia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4758,
+                "person_name": "João Victor Berti Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4759,
+                "person_name": "Leandro Baêta Lustosa Pontes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4760,
+                "person_name": "Luís Felippe Coutinho de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4761,
+                "person_name": "Matheus Oliveira Jagi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4762,
+                "person_name": "Messias Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4763,
+                "person_name": "Pablo Matheus Sattamini Belmiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4764,
+                "person_name": "Pâmella Gonçalves Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4765,
+                "person_name": "Pedro Mariani Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4766,
+                "person_name": "Rafael Depollo Vassena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4499,
+                "person_name": "Renato Santos Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4767,
+                "person_name": "Tiago Felipe Vivaldi Braga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4768,
+                "person_name": "Victor Samuel Batista Alvarenga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4769,
+                "person_name": "Vinícius Reinholz de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 290,
                 "person_name": "Hilário Tomaz Alves De Oliveira",
@@ -3638,7 +13803,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 212,
+            "name": "Laboratório de Inteligência Computacional e Sistemas de informação"
+        }
     },
     {
         "id": 39,
@@ -3661,6 +13830,1140 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 351,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 352,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3723,
+                "person_name": "Avelino Forechi Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-25T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3725,
+                "person_name": "Felipe Nascimento Martins",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-10T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 2415,
+                "person_name": "Hudson Cassio Gomes de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3729,
+                "person_name": "Rafael Peixoto Derenzi Vivacqua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3730,
+                "person_name": "Reginaldo Corteletti",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-14T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3731,
+                "person_name": "Teodiano Freire Bastos Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-10T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3733,
+                "person_name": "Adjuto Martins Vasconcelos Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3734,
+                "person_name": "Akilanny Silva Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3735,
+                "person_name": "Alan Pablo Donati Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3736,
+                "person_name": "Allicia Rocha dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3737,
+                "person_name": "Alter DIego do Nascimento Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3738,
+                "person_name": "Álvaro Soldani Gondim de Freitas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3739,
+                "person_name": "Amanda Balestreiro Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3740,
+                "person_name": "Amanda Frasson Nascimento Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-12-15T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3741,
+                "person_name": "Ana Carolina Ichimura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3742,
+                "person_name": "Ana Carolina Ichimura Bermudes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3743,
+                "person_name": "Ana Luiza Alves da Silva do Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3744,
+                "person_name": "Ana Paula Costa de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3745,
+                "person_name": "Andre Barbosa da Vitoria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3746,
+                "person_name": "Bárbara Fábri Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3747,
+                "person_name": "Bruna Heringer Xavier",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3748,
+                "person_name": "Bruno Meschiatti Vasconcellos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3749,
+                "person_name": "Bruno Rocha Pratti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3750,
+                "person_name": "Carlos Eduardo Gomes Reddo Alves",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3751,
+                "person_name": "Carlos Henrique Gomes Correia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3752,
+                "person_name": "Cecilia Tavares Barreto",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3753,
+                "person_name": "Claudio Leandro Nascimento Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-25T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3754,
+                "person_name": "Cleiton Máximo Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3755,
+                "person_name": "Danilo da Silva Alvarez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-08T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3756,
+                "person_name": "Debora Galavote Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3757,
+                "person_name": "Diego Luchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3758,
+                "person_name": "Eduarda Assis de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3759,
+                "person_name": "Eduardo de Oliveira Pereira Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3760,
+                "person_name": "Eliabe de Assis Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3761,
+                "person_name": "Elisa De Pinho Pires Marinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3762,
+                "person_name": "Enthoni Araujo Fontis Serafim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3763,
+                "person_name": "Enzo Medeiros Agnez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3764,
+                "person_name": "Erick Kenzo Komati",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3765,
+                "person_name": "Estevão Nolasco Fonseca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3766,
+                "person_name": "Fábio Pinto Monte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3767,
+                "person_name": "Filipe Suhett Nogueira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3768,
+                "person_name": "Flávio Fonsêca de Mendonça",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3769,
+                "person_name": "Frederico Arleu Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3770,
+                "person_name": "Gabriel Saade Pagani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-03-19T00:00:00"
+            },
+            {
+                "person_id": 3771,
+                "person_name": "Guilherme Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3772,
+                "person_name": "Gustavo Amora Basílio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3774,
+                "person_name": "Heitor Libardi Bezerra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3775,
+                "person_name": "Israel de Morais Madalena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-10-14T00:00:00"
+            },
+            {
+                "person_id": 3776,
+                "person_name": "Israel Magalhães do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3777,
+                "person_name": "Jéssica Vieira Alvarenga dos Passos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3778,
+                "person_name": "João Paulo Gusmão Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3779,
+                "person_name": "João Victor Ferreira Abrêu",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2023-12-15T00:00:00"
+            },
+            {
+                "person_id": 3780,
+                "person_name": "João Vitor Silveira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3781,
+                "person_name": "Julia Sagrillo Barreiros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3782,
+                "person_name": "Kamila Maria Vieira Pralon",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3783,
+                "person_name": "Klara Matos Gazoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3784,
+                "person_name": "Luca da Gama Wyatt",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3785,
+                "person_name": "Lucas Rigo Tofoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3786,
+                "person_name": "Lucio Antonio Stange Venturim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3787,
+                "person_name": "Ludmila Dias",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3012,
+                "person_name": "Luiz Soneghet Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-11-04T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3181,
+                "person_name": "Magnu Windell Araújo Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2021-02-23T00:00:00"
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3789,
+                "person_name": "Marlon de Oliveira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3790,
+                "person_name": "Marlon Woelffel Candoti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-10-02T00:00:00"
+            },
+            {
+                "person_id": 3791,
+                "person_name": "Mateus Emanuel Mamani Araujo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-03T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3792,
+                "person_name": "Matheus de Araujo Nogueira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2021-12-06T00:00:00"
+            },
+            {
+                "person_id": 3793,
+                "person_name": "Matheus Inácio Silva Mol",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3794,
+                "person_name": "Mayannara Trindade Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3795,
+                "person_name": "Miguel Gonçalves Schroeffer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3796,
+                "person_name": "Nicoly Ferreira dos Santos Pazini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": "2025-12-18T00:00:00"
+            },
+            {
+                "person_id": 3797,
+                "person_name": "Raphael Rebello Haddad",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3798,
+                "person_name": "Rodrigo Gomes Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3799,
+                "person_name": "Rodrigo Piol Capucho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3800,
+                "person_name": "Sandy Keury Matos Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3801,
+                "person_name": "Sérgio Daniel Camponez Leal",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3802,
+                "person_name": "Thaís da Silva Ferrarini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3803,
+                "person_name": "Thiago Almeida deps Caldeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3805,
+                "person_name": "Thiago de Oliveira Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-08-23T00:00:00"
+            },
+            {
+                "person_id": 3806,
+                "person_name": "Vitor do Nascimento Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3807,
+                "person_name": "Walter Adriani Gazolli Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3808,
+                "person_name": "Yasmim Alessa Paulino Romero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 4770,
+                "person_name": "Adriano Marcio Sgrancio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-06-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1198,
+                "person_name": "Leonardo Aguiar do Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4771,
+                "person_name": "Leonardo Azevedo Scardua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4772,
+                "person_name": "Marcos Paulo Kohler Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-06T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-05-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4773,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4774,
+                "person_name": "Amanda Paiva de Souza Silveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4775,
+                "person_name": "Ana Clara Dalvin Del Piero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4776,
+                "person_name": "Analice Clarindo Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4777,
+                "person_name": "Arthur Fabrício Da Silva Pires de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4778,
+                "person_name": "David de Assis",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4779,
+                "person_name": "Iago Moraes De Marchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4780,
+                "person_name": "Joaquim Estefan Vivas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4781,
+                "person_name": "Kauã Alexandre Bernardes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4782,
+                "person_name": "Lavínia Lima Rodrigues da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4783,
+                "person_name": "Lucas Amorim Silva Gois",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4784,
+                "person_name": "Lucas Stefanelli Vieira Stefanelli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4785,
+                "person_name": "Lucca Richa Campagnoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4786,
+                "person_name": "Luma Tavares Lopes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4787,
+                "person_name": "Maria Clara De Moura E Silva Barcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4788,
+                "person_name": "Maria Clara Peterle de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-02-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4789,
+                "person_name": "Myllena Furtado Toniato",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4790,
+                "person_name": "Pedro Henrique Albani Nunes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4791,
+                "person_name": "Raíssa Andrade Dutra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4792,
+                "person_name": "Rian Dezan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4793,
+                "person_name": "Sofia Alves FIgueredo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4794,
+                "person_name": "Tertuliano dos Santos Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4795,
+                "person_name": "Valentina Sobral Endringer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4796,
+                "person_name": "Victória Da Silva Maciel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4797,
+                "person_name": "Wallace da Costa Ferreira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1198,
                 "person_name": "Leonardo Aguiar do Amaral",
@@ -3698,7 +15001,11 @@
                 "start_date": "2025-09-02T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 256,
+            "name": "Núcleo de Estudos em Robótica e Automação"
+        }
     },
     {
         "id": 40,
@@ -3721,6 +15028,123 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 348,
+                "person_name": "Leandro Melo de Sa",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 349,
+                "person_name": "Rosilene De Sa Ribeiro",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-05T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-05T00:00:00",
+                "end_date": "2023-02-27T00:00:00"
+            },
+            {
+                "person_id": 3694,
+                "person_name": "Estácio Righetti Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-23T00:00:00",
+                "end_date": "2020-03-24T00:00:00"
+            },
+            {
+                "person_id": 3695,
+                "person_name": "Faye Manski Queiroz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3696,
+                "person_name": "Gustavo Roque Santa Clara",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-23T00:00:00",
+                "end_date": "2020-03-24T00:00:00"
+            },
+            {
+                "person_id": 3697,
+                "person_name": "Hugo Ramalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-23T00:00:00",
+                "end_date": "2020-03-24T00:00:00"
+            },
+            {
+                "person_id": 3183,
+                "person_name": "Julia Nunes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-26T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3698,
+                "person_name": "Livia Pinto Rocha",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-07-06T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3699,
+                "person_name": "Lucas Eduardo da Silva Pacheco",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-07-06T00:00:00",
+                "end_date": "2023-02-27T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-17T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 348,
                 "person_name": "Leandro Melo de Sa",
@@ -3758,7 +15182,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 253,
+            "name": "NUCLEO DE ESTUDOS EM ENSINO DE FISICA"
+        }
     },
     {
         "id": 41,
@@ -3863,7 +15291,8 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 42,
@@ -3886,6 +15315,1140 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 351,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 352,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3723,
+                "person_name": "Avelino Forechi Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-25T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3725,
+                "person_name": "Felipe Nascimento Martins",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-10T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 2415,
+                "person_name": "Hudson Cassio Gomes de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3729,
+                "person_name": "Rafael Peixoto Derenzi Vivacqua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3730,
+                "person_name": "Reginaldo Corteletti",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-14T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3731,
+                "person_name": "Teodiano Freire Bastos Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-10T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3733,
+                "person_name": "Adjuto Martins Vasconcelos Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3734,
+                "person_name": "Akilanny Silva Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3735,
+                "person_name": "Alan Pablo Donati Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3736,
+                "person_name": "Allicia Rocha dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3737,
+                "person_name": "Alter DIego do Nascimento Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3738,
+                "person_name": "Álvaro Soldani Gondim de Freitas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3739,
+                "person_name": "Amanda Balestreiro Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3740,
+                "person_name": "Amanda Frasson Nascimento Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-12-15T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3741,
+                "person_name": "Ana Carolina Ichimura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3742,
+                "person_name": "Ana Carolina Ichimura Bermudes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3743,
+                "person_name": "Ana Luiza Alves da Silva do Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3744,
+                "person_name": "Ana Paula Costa de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3745,
+                "person_name": "Andre Barbosa da Vitoria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3746,
+                "person_name": "Bárbara Fábri Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3747,
+                "person_name": "Bruna Heringer Xavier",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3748,
+                "person_name": "Bruno Meschiatti Vasconcellos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3749,
+                "person_name": "Bruno Rocha Pratti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3750,
+                "person_name": "Carlos Eduardo Gomes Reddo Alves",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3751,
+                "person_name": "Carlos Henrique Gomes Correia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3752,
+                "person_name": "Cecilia Tavares Barreto",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3753,
+                "person_name": "Claudio Leandro Nascimento Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-25T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3754,
+                "person_name": "Cleiton Máximo Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3755,
+                "person_name": "Danilo da Silva Alvarez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-08T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3756,
+                "person_name": "Debora Galavote Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3757,
+                "person_name": "Diego Luchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3758,
+                "person_name": "Eduarda Assis de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3759,
+                "person_name": "Eduardo de Oliveira Pereira Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3760,
+                "person_name": "Eliabe de Assis Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3761,
+                "person_name": "Elisa De Pinho Pires Marinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3762,
+                "person_name": "Enthoni Araujo Fontis Serafim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3763,
+                "person_name": "Enzo Medeiros Agnez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3764,
+                "person_name": "Erick Kenzo Komati",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3765,
+                "person_name": "Estevão Nolasco Fonseca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3766,
+                "person_name": "Fábio Pinto Monte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3767,
+                "person_name": "Filipe Suhett Nogueira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3768,
+                "person_name": "Flávio Fonsêca de Mendonça",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3769,
+                "person_name": "Frederico Arleu Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3770,
+                "person_name": "Gabriel Saade Pagani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-03-19T00:00:00"
+            },
+            {
+                "person_id": 3771,
+                "person_name": "Guilherme Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3772,
+                "person_name": "Gustavo Amora Basílio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3774,
+                "person_name": "Heitor Libardi Bezerra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3775,
+                "person_name": "Israel de Morais Madalena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-10-14T00:00:00"
+            },
+            {
+                "person_id": 3776,
+                "person_name": "Israel Magalhães do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3777,
+                "person_name": "Jéssica Vieira Alvarenga dos Passos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3778,
+                "person_name": "João Paulo Gusmão Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3779,
+                "person_name": "João Victor Ferreira Abrêu",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2023-12-15T00:00:00"
+            },
+            {
+                "person_id": 3780,
+                "person_name": "João Vitor Silveira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3781,
+                "person_name": "Julia Sagrillo Barreiros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3782,
+                "person_name": "Kamila Maria Vieira Pralon",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3783,
+                "person_name": "Klara Matos Gazoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3784,
+                "person_name": "Luca da Gama Wyatt",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3785,
+                "person_name": "Lucas Rigo Tofoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3786,
+                "person_name": "Lucio Antonio Stange Venturim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3787,
+                "person_name": "Ludmila Dias",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3012,
+                "person_name": "Luiz Soneghet Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-11-04T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3181,
+                "person_name": "Magnu Windell Araújo Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2021-02-23T00:00:00"
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3789,
+                "person_name": "Marlon de Oliveira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3790,
+                "person_name": "Marlon Woelffel Candoti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-10-02T00:00:00"
+            },
+            {
+                "person_id": 3791,
+                "person_name": "Mateus Emanuel Mamani Araujo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-03T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3792,
+                "person_name": "Matheus de Araujo Nogueira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2021-12-06T00:00:00"
+            },
+            {
+                "person_id": 3793,
+                "person_name": "Matheus Inácio Silva Mol",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3794,
+                "person_name": "Mayannara Trindade Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3795,
+                "person_name": "Miguel Gonçalves Schroeffer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3796,
+                "person_name": "Nicoly Ferreira dos Santos Pazini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": "2025-12-18T00:00:00"
+            },
+            {
+                "person_id": 3797,
+                "person_name": "Raphael Rebello Haddad",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3798,
+                "person_name": "Rodrigo Gomes Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3799,
+                "person_name": "Rodrigo Piol Capucho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3800,
+                "person_name": "Sandy Keury Matos Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3801,
+                "person_name": "Sérgio Daniel Camponez Leal",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3802,
+                "person_name": "Thaís da Silva Ferrarini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3803,
+                "person_name": "Thiago Almeida deps Caldeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3805,
+                "person_name": "Thiago de Oliveira Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-08-23T00:00:00"
+            },
+            {
+                "person_id": 3806,
+                "person_name": "Vitor do Nascimento Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3807,
+                "person_name": "Walter Adriani Gazolli Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3808,
+                "person_name": "Yasmim Alessa Paulino Romero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 4770,
+                "person_name": "Adriano Marcio Sgrancio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-06-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1198,
+                "person_name": "Leonardo Aguiar do Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4771,
+                "person_name": "Leonardo Azevedo Scardua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4772,
+                "person_name": "Marcos Paulo Kohler Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-06T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-05-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4773,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4774,
+                "person_name": "Amanda Paiva de Souza Silveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4775,
+                "person_name": "Ana Clara Dalvin Del Piero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4776,
+                "person_name": "Analice Clarindo Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4777,
+                "person_name": "Arthur Fabrício Da Silva Pires de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4778,
+                "person_name": "David de Assis",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4779,
+                "person_name": "Iago Moraes De Marchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4780,
+                "person_name": "Joaquim Estefan Vivas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4781,
+                "person_name": "Kauã Alexandre Bernardes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4782,
+                "person_name": "Lavínia Lima Rodrigues da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4783,
+                "person_name": "Lucas Amorim Silva Gois",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4784,
+                "person_name": "Lucas Stefanelli Vieira Stefanelli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4785,
+                "person_name": "Lucca Richa Campagnoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4786,
+                "person_name": "Luma Tavares Lopes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4787,
+                "person_name": "Maria Clara De Moura E Silva Barcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4788,
+                "person_name": "Maria Clara Peterle de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-02-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4789,
+                "person_name": "Myllena Furtado Toniato",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4790,
+                "person_name": "Pedro Henrique Albani Nunes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4791,
+                "person_name": "Raíssa Andrade Dutra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4792,
+                "person_name": "Rian Dezan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4793,
+                "person_name": "Sofia Alves FIgueredo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4794,
+                "person_name": "Tertuliano dos Santos Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4795,
+                "person_name": "Valentina Sobral Endringer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4796,
+                "person_name": "Victória Da Silva Maciel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4797,
+                "person_name": "Wallace da Costa Ferreira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1198,
                 "person_name": "Leonardo Aguiar do Amaral",
@@ -3959,7 +16522,11 @@
                 "start_date": "2025-04-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 256,
+            "name": "Núcleo de Estudos em Robótica e Automação"
+        }
     },
     {
         "id": 43,
@@ -3982,6 +16549,222 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 114,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 115,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-08-09T00:00:00",
+                "end_date": "2024-10-22T00:00:00"
+            },
+            {
+                "person_id": 1660,
+                "person_name": "Rodrigo Altoé",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-03-10T00:00:00"
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-26T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1663,
+                "person_name": "Douglas Souza Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1664,
+                "person_name": "Enzo Salamão Roseiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1665,
+                "person_name": "Fernanda Mayumi Fukai",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1666,
+                "person_name": "Heidy de Oliveira Simões",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1667,
+                "person_name": "Juliana Dalmaso da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1668,
+                "person_name": "Kessia Klein Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-10-28T00:00:00"
+            },
+            {
+                "person_id": 1669,
+                "person_name": "Marciel Mario Degasperi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1670,
+                "person_name": "Marjorie Ariele Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1671,
+                "person_name": "Matheus Santiago Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-13T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1672,
+                "person_name": "Paulo José de Almeida Barbosa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1673,
+                "person_name": "Renan Oliveira de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1674,
+                "person_name": "Reynan Giacomin Borlini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-12-05T00:00:00"
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4709,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-07-30T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1737,
                 "person_name": "Cassius Zanetti Resende",
@@ -4010,7 +16793,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 85,
+            "name": "Grupo de Aprendizado de Máquina e Automação"
+        }
     },
     {
         "id": 44,
@@ -4033,6 +16820,1140 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 351,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 352,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3723,
+                "person_name": "Avelino Forechi Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-25T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3725,
+                "person_name": "Felipe Nascimento Martins",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3728,
+                "person_name": "Gabriel Tozatto Zago",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-10T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 2415,
+                "person_name": "Hudson Cassio Gomes de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3729,
+                "person_name": "Rafael Peixoto Derenzi Vivacqua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3730,
+                "person_name": "Reginaldo Corteletti",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-05-14T00:00:00",
+                "end_date": "2018-11-11T00:00:00"
+            },
+            {
+                "person_id": 3731,
+                "person_name": "Teodiano Freire Bastos Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-10T00:00:00",
+                "end_date": "2024-03-25T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3733,
+                "person_name": "Adjuto Martins Vasconcelos Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3734,
+                "person_name": "Akilanny Silva Cruz",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3735,
+                "person_name": "Alan Pablo Donati Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3736,
+                "person_name": "Allicia Rocha dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3737,
+                "person_name": "Alter DIego do Nascimento Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3738,
+                "person_name": "Álvaro Soldani Gondim de Freitas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3739,
+                "person_name": "Amanda Balestreiro Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3740,
+                "person_name": "Amanda Frasson Nascimento Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-12-15T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3741,
+                "person_name": "Ana Carolina Ichimura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3742,
+                "person_name": "Ana Carolina Ichimura Bermudes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3743,
+                "person_name": "Ana Luiza Alves da Silva do Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3744,
+                "person_name": "Ana Paula Costa de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3745,
+                "person_name": "Andre Barbosa da Vitoria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3746,
+                "person_name": "Bárbara Fábri Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3747,
+                "person_name": "Bruna Heringer Xavier",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3748,
+                "person_name": "Bruno Meschiatti Vasconcellos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3749,
+                "person_name": "Bruno Rocha Pratti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3750,
+                "person_name": "Carlos Eduardo Gomes Reddo Alves",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3751,
+                "person_name": "Carlos Henrique Gomes Correia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3752,
+                "person_name": "Cecilia Tavares Barreto",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-02-14T00:00:00"
+            },
+            {
+                "person_id": 3753,
+                "person_name": "Claudio Leandro Nascimento Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-25T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3754,
+                "person_name": "Cleiton Máximo Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3755,
+                "person_name": "Danilo da Silva Alvarez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-08T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3756,
+                "person_name": "Debora Galavote Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3757,
+                "person_name": "Diego Luchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3758,
+                "person_name": "Eduarda Assis de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3759,
+                "person_name": "Eduardo de Oliveira Pereira Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3760,
+                "person_name": "Eliabe de Assis Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3761,
+                "person_name": "Elisa De Pinho Pires Marinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3762,
+                "person_name": "Enthoni Araujo Fontis Serafim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3763,
+                "person_name": "Enzo Medeiros Agnez",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3764,
+                "person_name": "Erick Kenzo Komati",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3765,
+                "person_name": "Estevão Nolasco Fonseca",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3766,
+                "person_name": "Fábio Pinto Monte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3767,
+                "person_name": "Filipe Suhett Nogueira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3768,
+                "person_name": "Flávio Fonsêca de Mendonça",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3769,
+                "person_name": "Frederico Arleu Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-05-24T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3770,
+                "person_name": "Gabriel Saade Pagani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-03-19T00:00:00"
+            },
+            {
+                "person_id": 3771,
+                "person_name": "Guilherme Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 3772,
+                "person_name": "Gustavo Amora Basílio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-02T00:00:00"
+            },
+            {
+                "person_id": 3774,
+                "person_name": "Heitor Libardi Bezerra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3775,
+                "person_name": "Israel de Morais Madalena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-10-14T00:00:00"
+            },
+            {
+                "person_id": 3776,
+                "person_name": "Israel Magalhães do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3777,
+                "person_name": "Jéssica Vieira Alvarenga dos Passos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": "2019-06-27T00:00:00"
+            },
+            {
+                "person_id": 3778,
+                "person_name": "João Paulo Gusmão Teixeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3779,
+                "person_name": "João Victor Ferreira Abrêu",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2023-12-15T00:00:00"
+            },
+            {
+                "person_id": 3780,
+                "person_name": "João Vitor Silveira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-16T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3781,
+                "person_name": "Julia Sagrillo Barreiros",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3782,
+                "person_name": "Kamila Maria Vieira Pralon",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3783,
+                "person_name": "Klara Matos Gazoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-07T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3784,
+                "person_name": "Luca da Gama Wyatt",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3785,
+                "person_name": "Lucas Rigo Tofoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2023-03-22T00:00:00"
+            },
+            {
+                "person_id": 1999,
+                "person_name": "Lucas Silverio Gums",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-04T00:00:00",
+                "end_date": "2025-03-16T00:00:00"
+            },
+            {
+                "person_id": 3786,
+                "person_name": "Lucio Antonio Stange Venturim",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2022-04-07T00:00:00"
+            },
+            {
+                "person_id": 3787,
+                "person_name": "Ludmila Dias",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3012,
+                "person_name": "Luiz Soneghet Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-11-04T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3181,
+                "person_name": "Magnu Windell Araújo Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2021-02-23T00:00:00"
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-22T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3789,
+                "person_name": "Marlon de Oliveira Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3790,
+                "person_name": "Marlon Woelffel Candoti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-10-02T00:00:00"
+            },
+            {
+                "person_id": 3791,
+                "person_name": "Mateus Emanuel Mamani Araujo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-03T00:00:00",
+                "end_date": "2021-02-22T00:00:00"
+            },
+            {
+                "person_id": 3792,
+                "person_name": "Matheus de Araujo Nogueira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-06T00:00:00",
+                "end_date": "2021-12-06T00:00:00"
+            },
+            {
+                "person_id": 3793,
+                "person_name": "Matheus Inácio Silva Mol",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3794,
+                "person_name": "Mayannara Trindade Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3795,
+                "person_name": "Miguel Gonçalves Schroeffer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-04-05T00:00:00",
+                "end_date": "2017-07-11T00:00:00"
+            },
+            {
+                "person_id": 3796,
+                "person_name": "Nicoly Ferreira dos Santos Pazini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": "2025-12-18T00:00:00"
+            },
+            {
+                "person_id": 3797,
+                "person_name": "Raphael Rebello Haddad",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3798,
+                "person_name": "Rodrigo Gomes Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3799,
+                "person_name": "Rodrigo Piol Capucho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-06-28T00:00:00",
+                "end_date": "2020-03-03T00:00:00"
+            },
+            {
+                "person_id": 3800,
+                "person_name": "Sandy Keury Matos Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3801,
+                "person_name": "Sérgio Daniel Camponez Leal",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 3802,
+                "person_name": "Thaís da Silva Ferrarini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2016-10-10T00:00:00",
+                "end_date": "2017-09-01T00:00:00"
+            },
+            {
+                "person_id": 3803,
+                "person_name": "Thiago Almeida deps Caldeira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-09-13T00:00:00"
+            },
+            {
+                "person_id": 3805,
+                "person_name": "Thiago de Oliveira Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2017-07-11T00:00:00",
+                "end_date": "2017-08-23T00:00:00"
+            },
+            {
+                "person_id": 3806,
+                "person_name": "Vitor do Nascimento Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-14T00:00:00",
+                "end_date": "2024-03-27T00:00:00"
+            },
+            {
+                "person_id": 3807,
+                "person_name": "Walter Adriani Gazolli Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-03-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3808,
+                "person_name": "Yasmim Alessa Paulino Romero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": "2025-11-05T00:00:00"
+            },
+            {
+                "person_id": 4770,
+                "person_name": "Adriano Marcio Sgrancio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-06-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1198,
+                "person_name": "Leonardo Aguiar do Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4771,
+                "person_name": "Leonardo Azevedo Scardua",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4772,
+                "person_name": "Marcos Paulo Kohler Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-06T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-05-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4773,
+                "person_name": "Richard Junior Manuel Godinez Tello",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4774,
+                "person_name": "Amanda Paiva de Souza Silveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4775,
+                "person_name": "Ana Clara Dalvin Del Piero",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4776,
+                "person_name": "Analice Clarindo Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4777,
+                "person_name": "Arthur Fabrício Da Silva Pires de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4778,
+                "person_name": "David de Assis",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4779,
+                "person_name": "Iago Moraes De Marchi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4780,
+                "person_name": "Joaquim Estefan Vivas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4781,
+                "person_name": "Kauã Alexandre Bernardes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1996,
+                "person_name": "Larissa Maciel Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4782,
+                "person_name": "Lavínia Lima Rodrigues da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4783,
+                "person_name": "Lucas Amorim Silva Gois",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4784,
+                "person_name": "Lucas Stefanelli Vieira Stefanelli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4785,
+                "person_name": "Lucca Richa Campagnoli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4786,
+                "person_name": "Luma Tavares Lopes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-09-14T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4787,
+                "person_name": "Maria Clara De Moura E Silva Barcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4788,
+                "person_name": "Maria Clara Peterle de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-02-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4789,
+                "person_name": "Myllena Furtado Toniato",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4790,
+                "person_name": "Pedro Henrique Albani Nunes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4791,
+                "person_name": "Raíssa Andrade Dutra",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4792,
+                "person_name": "Rian Dezan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4793,
+                "person_name": "Sofia Alves FIgueredo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-15T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4794,
+                "person_name": "Tertuliano dos Santos Junior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4795,
+                "person_name": "Valentina Sobral Endringer",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-05-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4796,
+                "person_name": "Victória Da Silva Maciel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4797,
+                "person_name": "Wallace da Costa Ferreira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-11-05T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4772,
                 "person_name": "Marcos Paulo Kohler Caldas",
@@ -4070,7 +17991,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 256,
+            "name": "Núcleo de Estudos em Robótica e Automação"
+        }
     },
     {
         "id": 45,
@@ -4094,6 +18019,537 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 3219,
                 "person_name": "Sérgio Nery Simões",
                 "roles": [
@@ -4112,7 +18568,11 @@
                 "start_date": "2025-09-29T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 46,
@@ -4135,6 +18595,537 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3219,
                 "person_name": "Sérgio Nery Simões",
@@ -4181,7 +19172,11 @@
                 "start_date": "2025-09-29T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 47,
@@ -4205,6 +19200,168 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 250,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 251,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-04-01T00:00:00",
+                "end_date": "2025-03-20T00:00:00"
+            },
+            {
+                "person_id": 2782,
+                "person_name": "Cleber Silva Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": "2021-12-18T00:00:00"
+            },
+            {
+                "person_id": 2783,
+                "person_name": "Giancarlo Oliveira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-07T00:00:00"
+            },
+            {
+                "person_id": 2784,
+                "person_name": "Harrison Felipe Sanches Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-12-18T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4724,
+                "person_name": "Fábio de Oliveira Lima",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4725,
+                "person_name": "Gilmar Luiz Vassoler",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4726,
+                "person_name": "Adailton Saraiva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1569,
+                "person_name": "Alan Pancieri Berger Saar",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4727,
+                "person_name": "Ana Júlia Caetano Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4728,
+                "person_name": "Bruno Moreto de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4729,
+                "person_name": "Eduarda Nascimento Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4730,
+                "person_name": "Jeorge Terci Gasperazzo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4731,
+                "person_name": "Leonardo Zuchi Guio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 3813,
                 "person_name": "Leandro Colombi Resendo",
                 "roles": [
@@ -4223,7 +19380,11 @@
                 "start_date": "2025-12-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 178,
+            "name": "Grupo de Pesquisa em Redes e Otimização"
+        }
     },
     {
         "id": 48,
@@ -4250,13 +19411,575 @@
                 "person_id": 290,
                 "person_name": "Hilário Tomaz Alves De Oliveira",
                 "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 291,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3213,
+                "person_name": "Ernani Leite Ribeiro Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3214,
+                "person_name": "Fabiano Borges Ruy",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-29T00:00:00",
+                "end_date": "2023-04-03T00:00:00"
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-09-25T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3218,
+                "person_name": "Ronaldo Aparecida Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 3220,
+                "person_name": "Antonio Ricardo Alexandre Brasil",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3221,
+                "person_name": "Gustavo Grimaldi Campello",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3222,
+                "person_name": "Hanna Tátila de Sousa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3223,
+                "person_name": "João Carlos Pandolfi Santana",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3224,
+                "person_name": "Lucas Dipré Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3225,
+                "person_name": "Pedro Henrique Borges Lopes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3226,
+                "person_name": "Rafael Broédel Pedroni",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3227,
+                "person_name": "Thanner Soares Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3228,
+                "person_name": "Victor Gonçalves Valfré",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-09-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4733,
+                "person_name": "Filipe Wall Mutz",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4734,
+                "person_name": "Hilário Tomaz Alves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4735,
+                "person_name": "Mateus Conrad Barcellos da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4736,
+                "person_name": "Rodrigo Fernandes Calhau",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4737,
+                "person_name": "Aline dos Santos Laranja Vileforte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4738,
+                "person_name": "Alvaro Vinicius de Almeida Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4739,
+                "person_name": "André Boechat Felipe",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4740,
+                "person_name": "Arthur Chisté Lucas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4741,
+                "person_name": "Arthur Corona Pimentel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4742,
+                "person_name": "Arthur Rafael Vital Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4743,
+                "person_name": "Calebe Ferreira Albertino",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4744,
+                "person_name": "Cleber de Jesus Salustiano",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4745,
+                "person_name": "Dafne Fernandes Piovesan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4746,
+                "person_name": "Daniel Folador Rossi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4747,
+                "person_name": "Danilo Xavier Valle",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4748,
+                "person_name": "Eliza Karyn dos Santos de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4749,
+                "person_name": "Erick Machado Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4750,
+                "person_name": "Fabio Bermudes Cabral",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-04-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4751,
+                "person_name": "Filipe Anunciação Batista de Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4752,
+                "person_name": "Gabriel Mota Bromonschenkel Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4753,
+                "person_name": "Gean Paulo Oliveira Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4754,
+                "person_name": "Gustavo Firme Fiorot",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4755,
+                "person_name": "Ilanna dos Reis Cardoso",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4756,
+                "person_name": "Jean Carlos Penas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4757,
+                "person_name": "Jhovany Paulo Schelemberg Murgia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4758,
+                "person_name": "João Victor Berti Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4759,
+                "person_name": "Leandro Baêta Lustosa Pontes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4760,
+                "person_name": "Luís Felippe Coutinho de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4761,
+                "person_name": "Matheus Oliveira Jagi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4762,
+                "person_name": "Messias Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4763,
+                "person_name": "Pablo Matheus Sattamini Belmiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4764,
+                "person_name": "Pâmella Gonçalves Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4765,
+                "person_name": "Pedro Mariani Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4766,
+                "person_name": "Rafael Depollo Vassena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4499,
+                "person_name": "Renato Santos Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4767,
+                "person_name": "Tiago Felipe Vivaldi Braga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4768,
+                "person_name": "Victor Samuel Batista Alvarenga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4769,
+                "person_name": "Vinícius Reinholz de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 290,
+                "person_name": "Hilário Tomaz Alves De Oliveira",
+                "roles": [
                     "Coordinator",
                     "Researcher"
                 ],
                 "start_date": "2024-03-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 212,
+            "name": "Laboratório de Inteligência Computacional e Sistemas de informação"
+        }
     },
     {
         "id": 49,
@@ -4279,6 +20002,294 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 71,
+                "person_name": "ALEXANDRE PEREIRA CHAHAD",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 72,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1335,
+                "person_name": "Alexandre Pereira Chahad",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1336,
+                "person_name": "Andre dos Santos Sampaio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1338,
+                "person_name": "Daniel Soares de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1339,
+                "person_name": "Evandro Chaves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 635,
+                "person_name": "Giusilene Costa de Souza Pinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1341,
+                "person_name": "José Alexandre de Souza Gadioli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1342,
+                "person_name": "Karla de Aleluia Batista",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1343,
+                "person_name": "Leandro Dias Cardoso Carvalho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1344,
+                "person_name": "Leandro Rodrigues da Silva Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1345,
+                "person_name": "Leonardo Garcia Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1346,
+                "person_name": "Leonardo Nazário Silva dos Santos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1347,
+                "person_name": "Lodovico Ortlieb Faria",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1348,
+                "person_name": "Ludovico Larsen Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1349,
+                "person_name": "Marcelo Gomes de Araújo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1350,
+                "person_name": "Marcos Aloízio França da Fonseca",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-09-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1351,
+                "person_name": "Maria Claudia Lima Couto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1352,
+                "person_name": "Maria das Graças Costa Nery da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1353,
+                "person_name": "Mônica Luize Sarabia",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1084,
+                "person_name": "Nágila de Fátima Rabelo Moraes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1355,
+                "person_name": "Pedro Pierro Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1356,
+                "person_name": "Rafael Breda Justo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1358,
+                "person_name": "Robson Ferreira de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1359,
+                "person_name": "Rodrigo Cândido Borges",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1360,
+                "person_name": "Rodrigo de Benedictis Delphino",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1361,
+                "person_name": "José Francisco Resende Salgado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1362,
+                "person_name": "Michel Gondim Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1357,
                 "person_name": "Rafael Emerick Zape de Oliveira",
@@ -4343,7 +20354,8 @@
                 "start_date": "2025-12-25T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 50,
@@ -4412,7 +20424,8 @@
                 "start_date": "2024-05-06T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 51,
@@ -4436,6 +20449,51 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 266,
+                "person_name": "Amarildo Mendes Lemos",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2950,
+                "person_name": "Amarildo Mendes Lemos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2951,
+                "person_name": "Ernesto Charpinel Borges",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1865,
+                "person_name": "Tiago de Araujo Camillo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-03-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2952,
+                "person_name": "Wander Luiz Demartini Nunes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 2950,
                 "person_name": "Amarildo Mendes Lemos",
                 "roles": [
@@ -4445,7 +20503,11 @@
                 "start_date": "2025-03-21T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 192,
+            "name": "História das interações políticas, culturais, econômicas e sociais"
+        }
     },
     {
         "id": 52,
@@ -4468,6 +20530,294 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 71,
+                "person_name": "ALEXANDRE PEREIRA CHAHAD",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 72,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1335,
+                "person_name": "Alexandre Pereira Chahad",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1336,
+                "person_name": "Andre dos Santos Sampaio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1338,
+                "person_name": "Daniel Soares de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1339,
+                "person_name": "Evandro Chaves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 635,
+                "person_name": "Giusilene Costa de Souza Pinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1341,
+                "person_name": "José Alexandre de Souza Gadioli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1342,
+                "person_name": "Karla de Aleluia Batista",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1343,
+                "person_name": "Leandro Dias Cardoso Carvalho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1344,
+                "person_name": "Leandro Rodrigues da Silva Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1345,
+                "person_name": "Leonardo Garcia Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1346,
+                "person_name": "Leonardo Nazário Silva dos Santos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1347,
+                "person_name": "Lodovico Ortlieb Faria",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1348,
+                "person_name": "Ludovico Larsen Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1349,
+                "person_name": "Marcelo Gomes de Araújo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1350,
+                "person_name": "Marcos Aloízio França da Fonseca",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-09-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1351,
+                "person_name": "Maria Claudia Lima Couto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1352,
+                "person_name": "Maria das Graças Costa Nery da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1353,
+                "person_name": "Mônica Luize Sarabia",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1084,
+                "person_name": "Nágila de Fátima Rabelo Moraes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1355,
+                "person_name": "Pedro Pierro Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1356,
+                "person_name": "Rafael Breda Justo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1358,
+                "person_name": "Robson Ferreira de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1359,
+                "person_name": "Rodrigo Cândido Borges",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1360,
+                "person_name": "Rodrigo de Benedictis Delphino",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1361,
+                "person_name": "José Francisco Resende Salgado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1362,
+                "person_name": "Michel Gondim Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1340,
                 "person_name": "Geraldo Andrade de Oliveira",
@@ -4505,7 +20855,8 @@
                 "start_date": "2025-12-19T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 53,
@@ -4529,6 +20880,564 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 290,
+                "person_name": "Hilário Tomaz Alves De Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 291,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3213,
+                "person_name": "Ernani Leite Ribeiro Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3214,
+                "person_name": "Fabiano Borges Ruy",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-29T00:00:00",
+                "end_date": "2023-04-03T00:00:00"
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-09-25T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3218,
+                "person_name": "Ronaldo Aparecida Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 3220,
+                "person_name": "Antonio Ricardo Alexandre Brasil",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3221,
+                "person_name": "Gustavo Grimaldi Campello",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3222,
+                "person_name": "Hanna Tátila de Sousa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3223,
+                "person_name": "João Carlos Pandolfi Santana",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3224,
+                "person_name": "Lucas Dipré Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3225,
+                "person_name": "Pedro Henrique Borges Lopes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3226,
+                "person_name": "Rafael Broédel Pedroni",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3227,
+                "person_name": "Thanner Soares Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3228,
+                "person_name": "Victor Gonçalves Valfré",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-09-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4733,
+                "person_name": "Filipe Wall Mutz",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4734,
+                "person_name": "Hilário Tomaz Alves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4735,
+                "person_name": "Mateus Conrad Barcellos da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4736,
+                "person_name": "Rodrigo Fernandes Calhau",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4737,
+                "person_name": "Aline dos Santos Laranja Vileforte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4738,
+                "person_name": "Alvaro Vinicius de Almeida Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4739,
+                "person_name": "André Boechat Felipe",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4740,
+                "person_name": "Arthur Chisté Lucas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4741,
+                "person_name": "Arthur Corona Pimentel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4742,
+                "person_name": "Arthur Rafael Vital Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4743,
+                "person_name": "Calebe Ferreira Albertino",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4744,
+                "person_name": "Cleber de Jesus Salustiano",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4745,
+                "person_name": "Dafne Fernandes Piovesan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4746,
+                "person_name": "Daniel Folador Rossi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4747,
+                "person_name": "Danilo Xavier Valle",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4748,
+                "person_name": "Eliza Karyn dos Santos de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4749,
+                "person_name": "Erick Machado Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4750,
+                "person_name": "Fabio Bermudes Cabral",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-04-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4751,
+                "person_name": "Filipe Anunciação Batista de Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4752,
+                "person_name": "Gabriel Mota Bromonschenkel Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4753,
+                "person_name": "Gean Paulo Oliveira Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4754,
+                "person_name": "Gustavo Firme Fiorot",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4755,
+                "person_name": "Ilanna dos Reis Cardoso",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4756,
+                "person_name": "Jean Carlos Penas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4757,
+                "person_name": "Jhovany Paulo Schelemberg Murgia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4758,
+                "person_name": "João Victor Berti Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4759,
+                "person_name": "Leandro Baêta Lustosa Pontes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4760,
+                "person_name": "Luís Felippe Coutinho de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4761,
+                "person_name": "Matheus Oliveira Jagi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4762,
+                "person_name": "Messias Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4763,
+                "person_name": "Pablo Matheus Sattamini Belmiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4764,
+                "person_name": "Pâmella Gonçalves Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4765,
+                "person_name": "Pedro Mariani Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4766,
+                "person_name": "Rafael Depollo Vassena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4499,
+                "person_name": "Renato Santos Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4767,
+                "person_name": "Tiago Felipe Vivaldi Braga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4768,
+                "person_name": "Victor Samuel Batista Alvarenga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4769,
+                "person_name": "Vinícius Reinholz de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 3732,
                 "person_name": "Thiago Meireles Paixão",
                 "roles": [
@@ -4547,7 +21456,11 @@
                 "start_date": "2025-11-05T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 212,
+            "name": "Laboratório de Inteligência Computacional e Sistemas de informação"
+        }
     },
     {
         "id": 54,
@@ -4570,6 +21483,168 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 250,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 251,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-04-01T00:00:00",
+                "end_date": "2025-03-20T00:00:00"
+            },
+            {
+                "person_id": 2782,
+                "person_name": "Cleber Silva Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": "2021-12-18T00:00:00"
+            },
+            {
+                "person_id": 2783,
+                "person_name": "Giancarlo Oliveira dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-07T00:00:00"
+            },
+            {
+                "person_id": 2784,
+                "person_name": "Harrison Felipe Sanches Machado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-12-18T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4724,
+                "person_name": "Fábio de Oliveira Lima",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4725,
+                "person_name": "Gilmar Luiz Vassoler",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-09-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4726,
+                "person_name": "Adailton Saraiva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1569,
+                "person_name": "Alan Pancieri Berger Saar",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4727,
+                "person_name": "Ana Júlia Caetano Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4728,
+                "person_name": "Bruno Moreto de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4729,
+                "person_name": "Eduarda Nascimento Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4730,
+                "person_name": "Jeorge Terci Gasperazzo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4731,
+                "person_name": "Leonardo Zuchi Guio",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-03-31T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 3810,
                 "person_name": "Cristina Klippel Dominicini",
@@ -4598,7 +21673,11 @@
                 "start_date": "2024-08-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 178,
+            "name": "Grupo de Pesquisa em Redes e Otimização"
+        }
     },
     {
         "id": 55,
@@ -4621,6 +21700,294 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 71,
+                "person_name": "ALEXANDRE PEREIRA CHAHAD",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 72,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1335,
+                "person_name": "Alexandre Pereira Chahad",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1336,
+                "person_name": "Andre dos Santos Sampaio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1338,
+                "person_name": "Daniel Soares de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1339,
+                "person_name": "Evandro Chaves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 635,
+                "person_name": "Giusilene Costa de Souza Pinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1341,
+                "person_name": "José Alexandre de Souza Gadioli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1342,
+                "person_name": "Karla de Aleluia Batista",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1343,
+                "person_name": "Leandro Dias Cardoso Carvalho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1344,
+                "person_name": "Leandro Rodrigues da Silva Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1345,
+                "person_name": "Leonardo Garcia Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1346,
+                "person_name": "Leonardo Nazário Silva dos Santos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1347,
+                "person_name": "Lodovico Ortlieb Faria",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1348,
+                "person_name": "Ludovico Larsen Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1349,
+                "person_name": "Marcelo Gomes de Araújo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1350,
+                "person_name": "Marcos Aloízio França da Fonseca",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-09-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1351,
+                "person_name": "Maria Claudia Lima Couto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1352,
+                "person_name": "Maria das Graças Costa Nery da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1353,
+                "person_name": "Mônica Luize Sarabia",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1084,
+                "person_name": "Nágila de Fátima Rabelo Moraes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1355,
+                "person_name": "Pedro Pierro Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1356,
+                "person_name": "Rafael Breda Justo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1358,
+                "person_name": "Robson Ferreira de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1359,
+                "person_name": "Rodrigo Cândido Borges",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1360,
+                "person_name": "Rodrigo de Benedictis Delphino",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1361,
+                "person_name": "José Francisco Resende Salgado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1362,
+                "person_name": "Michel Gondim Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1340,
                 "person_name": "Geraldo Andrade de Oliveira",
@@ -4694,7 +22061,8 @@
                 "start_date": "2025-12-29T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 56,
@@ -4718,6 +22086,249 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 158,
+                "person_name": "Larissy Alves Cotonhoto",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 159,
+                "person_name": "Josiane Beltrame Milanesi",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 160,
+                "person_name": "Sanandreia Torezani Perinni",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 161,
+                "person_name": "Emilene  Coco Dos Santos",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 162,
+                "person_name": "Sirley Trugilho da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 163,
+                "person_name": "Yvina Pavan Baldo",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 164,
+                "person_name": "Mariella Berger Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 48,
+                "person_name": "Gabriel Domingos Carvalho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 165,
+                "person_name": "Lidiane Leite Vasconcelos",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2113,
+                "person_name": "Adriana Pionttkovsky Barcellos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 2114,
+                "person_name": "Mariella Berger Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-03-04T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 2115,
+                "person_name": "Quezia Barbosa de Oliveira Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2023-04-25T00:00:00",
+                "end_date": "2024-03-14T00:00:00"
+            },
+            {
+                "person_id": 2116,
+                "person_name": "Suzana Maria Gotardo Chambela",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-11-11T00:00:00",
+                "end_date": "2023-04-25T00:00:00"
+            },
+            {
+                "person_id": 2117,
+                "person_name": "Allan Kelisson Verissimo Da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-27T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2118,
+                "person_name": "Andréia Cristina Carvalho Cáo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-25T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2119,
+                "person_name": "Clara Marques Bodart",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-25T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2120,
+                "person_name": "Flávia Cristina dos Santos Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-22T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2121,
+                "person_name": "Flávia Santos Rodrigues",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-29T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2122,
+                "person_name": "João Baptista Rios Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-22T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 454,
+                "person_name": "Levanildo Silva de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-25T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2123,
+                "person_name": "Luana Beatriz Reinholz Barbosa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-27T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2124,
+                "person_name": "Raíza Teixeira Griffo Vasconcelos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-25T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2125,
+                "person_name": "Rosiane Nascimento do Santíssimo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-05-25T00:00:00",
+                "end_date": "2025-12-03T00:00:00"
+            },
+            {
+                "person_id": 2126,
+                "person_name": "Sheila Moreira da Rocha Maggione",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-27T00:00:00",
+                "end_date": "2025-04-01T00:00:00"
+            },
+            {
+                "person_id": 2127,
+                "person_name": "Tamires Lacerda Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-27T00:00:00",
+                "end_date": "2023-04-27T00:00:00"
+            },
+            {
+                "person_id": 2128,
+                "person_name": "Uilliam Martins Torezani",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-27T00:00:00",
+                "end_date": "2023-04-27T00:00:00"
+            },
+            {
+                "person_id": 2129,
+                "person_name": "Veronica Loureiro Bridi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-04-27T00:00:00",
+                "end_date": "2023-04-27T00:00:00"
+            },
+            {
                 "person_id": 161,
                 "person_name": "Emilene  Coco Dos Santos",
                 "roles": [
@@ -4727,7 +22338,8 @@
                 "start_date": "2024-05-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 57,
@@ -4751,6 +22363,186 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 4715,
                 "person_name": "Rogério Passos do Amaral Pereira",
                 "roles": [
@@ -4769,7 +22561,11 @@
                 "start_date": "2024-04-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 58,
@@ -4793,6 +22589,564 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 290,
+                "person_name": "Hilário Tomaz Alves De Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 291,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3213,
+                "person_name": "Ernani Leite Ribeiro Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3214,
+                "person_name": "Fabiano Borges Ruy",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-29T00:00:00",
+                "end_date": "2023-04-03T00:00:00"
+            },
+            {
+                "person_id": 3216,
+                "person_name": "Marta Talitha Carvalho Freire Mendes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-09-25T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3218,
+                "person_name": "Ronaldo Aparecida Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-06-23T00:00:00",
+                "end_date": "2021-09-24T00:00:00"
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-20T00:00:00",
+                "end_date": "2018-05-29T00:00:00"
+            },
+            {
+                "person_id": 3220,
+                "person_name": "Antonio Ricardo Alexandre Brasil",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3221,
+                "person_name": "Gustavo Grimaldi Campello",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3222,
+                "person_name": "Hanna Tátila de Sousa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3223,
+                "person_name": "João Carlos Pandolfi Santana",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2016-05-20T00:00:00"
+            },
+            {
+                "person_id": 3224,
+                "person_name": "Lucas Dipré Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3225,
+                "person_name": "Pedro Henrique Borges Lopes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3226,
+                "person_name": "Rafael Broédel Pedroni",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-12-05T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 3227,
+                "person_name": "Thanner Soares Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2018-09-28T00:00:00"
+            },
+            {
+                "person_id": 3228,
+                "person_name": "Victor Gonçalves Valfré",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": "2019-08-08T00:00:00"
+            },
+            {
+                "person_id": 2292,
+                "person_name": "Bruno Cardoso Coutinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-09-28T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4733,
+                "person_name": "Filipe Wall Mutz",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-09-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3727,
+                "person_name": "Francisco de Assis Boldt",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4734,
+                "person_name": "Hilário Tomaz Alves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4735,
+                "person_name": "Mateus Conrad Barcellos da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4736,
+                "person_name": "Rodrigo Fernandes Calhau",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-09-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4737,
+                "person_name": "Aline dos Santos Laranja Vileforte",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4738,
+                "person_name": "Alvaro Vinicius de Almeida Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4739,
+                "person_name": "André Boechat Felipe",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4740,
+                "person_name": "Arthur Chisté Lucas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4741,
+                "person_name": "Arthur Corona Pimentel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4742,
+                "person_name": "Arthur Rafael Vital Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4743,
+                "person_name": "Calebe Ferreira Albertino",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4744,
+                "person_name": "Cleber de Jesus Salustiano",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4745,
+                "person_name": "Dafne Fernandes Piovesan",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4746,
+                "person_name": "Daniel Folador Rossi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2021-06-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4747,
+                "person_name": "Danilo Xavier Valle",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4748,
+                "person_name": "Eliza Karyn dos Santos de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4749,
+                "person_name": "Erick Machado Ferreira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4750,
+                "person_name": "Fabio Bermudes Cabral",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-04-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4751,
+                "person_name": "Filipe Anunciação Batista de Moura",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4752,
+                "person_name": "Gabriel Mota Bromonschenkel Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4753,
+                "person_name": "Gean Paulo Oliveira Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4754,
+                "person_name": "Gustavo Firme Fiorot",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4755,
+                "person_name": "Ilanna dos Reis Cardoso",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4756,
+                "person_name": "Jean Carlos Penas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4757,
+                "person_name": "Jhovany Paulo Schelemberg Murgia",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4758,
+                "person_name": "João Victor Berti Lima",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4759,
+                "person_name": "Leandro Baêta Lustosa Pontes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4760,
+                "person_name": "Luís Felippe Coutinho de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3788,
+                "person_name": "Marcos Vinicius Mendes Faria",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4761,
+                "person_name": "Matheus Oliveira Jagi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4762,
+                "person_name": "Messias Gomes da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-04-07T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4763,
+                "person_name": "Pablo Matheus Sattamini Belmiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4764,
+                "person_name": "Pâmella Gonçalves Martins",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4765,
+                "person_name": "Pedro Mariani Coelho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4766,
+                "person_name": "Rafael Depollo Vassena",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4499,
+                "person_name": "Renato Santos Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-27T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3804,
+                "person_name": "Thiago Borges Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4767,
+                "person_name": "Tiago Felipe Vivaldi Braga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4768,
+                "person_name": "Victor Samuel Batista Alvarenga",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-10-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4769,
+                "person_name": "Vinícius Reinholz de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-09T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 3732,
                 "person_name": "Thiago Meireles Paixão",
                 "roles": [
@@ -4811,7 +23165,11 @@
                 "start_date": "2024-09-25T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 212,
+            "name": "Laboratório de Inteligência Computacional e Sistemas de informação"
+        }
     },
     {
         "id": 59,
@@ -4835,6 +23193,222 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 114,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 115,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-08-09T00:00:00",
+                "end_date": "2024-10-22T00:00:00"
+            },
+            {
+                "person_id": 1660,
+                "person_name": "Rodrigo Altoé",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-03-10T00:00:00"
+            },
+            {
+                "person_id": 1661,
+                "person_name": "Rosiane Ribeiro Rocha",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-26T00:00:00"
+            },
+            {
+                "person_id": 1662,
+                "person_name": "Davi Aragão Ascacibas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1663,
+                "person_name": "Douglas Souza Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1664,
+                "person_name": "Enzo Salamão Roseiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1665,
+                "person_name": "Fernanda Mayumi Fukai",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2025-03-31T00:00:00"
+            },
+            {
+                "person_id": 1666,
+                "person_name": "Heidy de Oliveira Simões",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1667,
+                "person_name": "Juliana Dalmaso da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-03-01T00:00:00"
+            },
+            {
+                "person_id": 1668,
+                "person_name": "Kessia Klein Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2016-10-28T00:00:00"
+            },
+            {
+                "person_id": 1669,
+                "person_name": "Marciel Mario Degasperi",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1670,
+                "person_name": "Marjorie Ariele Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-12T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1671,
+                "person_name": "Matheus Santiago Ribeiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-03-13T00:00:00",
+                "end_date": "2025-11-27T00:00:00"
+            },
+            {
+                "person_id": 1672,
+                "person_name": "Paulo José de Almeida Barbosa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-03-12T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1673,
+                "person_name": "Renan Oliveira de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-03-10T00:00:00",
+                "end_date": "2024-03-12T00:00:00"
+            },
+            {
+                "person_id": 1674,
+                "person_name": "Reynan Giacomin Borlini",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-12-05T00:00:00"
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3726,
+                "person_name": "Flávio Garcia Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4709,
+                "person_name": "Luiz Alberto Pinto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-07-30T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 1337,
                 "person_name": "Daniel Cruz Cavalieri",
                 "roles": [
@@ -4853,7 +23427,11 @@
                 "start_date": "2025-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 85,
+            "name": "Grupo de Aprendizado de Máquina e Automação"
+        }
     },
     {
         "id": 60,
@@ -4877,6 +23455,537 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 2486,
                 "person_name": "Karin Satie Komati",
                 "roles": [
@@ -4886,7 +23995,11 @@
                 "start_date": "2025-10-02T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 61,
@@ -4909,6 +24022,213 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 122,
+                "person_name": "Flavio Barcelos Braz Da Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 123,
+                "person_name": "Danilo De Paula E Silva",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 983,
+                "person_name": "Adilson Ribeiro Prado",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1736,
+                "person_name": "Bene Régis Figueiredo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1737,
+                "person_name": "Cassius Zanetti Resende",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2022-08-03T00:00:00"
+            },
+            {
+                "person_id": 1099,
+                "person_name": "Giovani Zanetti Neto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1738,
+                "person_name": "Leandro Melo de Sá",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1739,
+                "person_name": "Rosilene de Sá Ribeiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-05-02T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1740,
+                "person_name": "Tiago Malavazi de Christo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-10-20T00:00:00",
+                "end_date": "2021-03-16T00:00:00"
+            },
+            {
+                "person_id": 1741,
+                "person_name": "Wagner Teixeira da Costa",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2021-03-24T00:00:00"
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-10-05T00:00:00"
+            },
+            {
+                "person_id": 1742,
+                "person_name": "Dárcio Leitão Quintas",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1743,
+                "person_name": "Felipe Morilho de Castro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 1744,
+                "person_name": "Guilherme Lima Barbarioli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2014-06-25T00:00:00"
+            },
+            {
+                "person_id": 4716,
+                "person_name": "Danilo de Paula e Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-02T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4717,
+                "person_name": "Edmilson Bermudes Rocha Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-02-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2851,
+                "person_name": "João Vitor Ferreira Duque",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-30T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4718,
+                "person_name": "Jussara Farias Fardin",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2022-05-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4719,
+                "person_name": "Renato Tannure Rotta de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-10-05T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4720,
+                "person_name": "Renner Sartório Camargo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-03-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1658,
+                "person_name": "Vinícius Secchin de Melo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-11-19T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4719,
                 "person_name": "Renato Tannure Rotta de Almeida",
@@ -4937,7 +24257,11 @@
                 "start_date": "2025-06-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 90,
+            "name": "Grupo de Energias Renováveis para Automação"
+        }
     },
     {
         "id": 62,
@@ -4964,13 +24288,548 @@
                 "person_id": 355,
                 "person_name": "Jefferson O. Andrade",
                 "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
                     "Coordinator",
                     "Researcher"
                 ],
                 "start_date": "2025-02-19T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 63,
@@ -4993,6 +24852,186 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 116,
+                "person_name": "Marco Antonio De Souza Leite Cuadros",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 117,
+                "person_name": "Gustavo Maia De Almeida",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1675,
+                "person_name": "Wallas Gusmão Thomas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": "2024-11-19T00:00:00"
+            },
+            {
+                "person_id": 1676,
+                "person_name": "Caio Lopes de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1677,
+                "person_name": "Joabe Ruella da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1678,
+                "person_name": "Leonardo Gonçalves Batista",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1679,
+                "person_name": "Lucas Mantuan Ayres",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1680,
+                "person_name": "Matheus Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1681,
+                "person_name": "Pablo France Salarolli",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1682,
+                "person_name": "Ravena Soares Monteiro",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1683,
+                "person_name": "Igor Rodrigues Cassimiro",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1684,
+                "person_name": "João Guilherme Lourenço de Souza",
+                "roles": [
+                    "Técnico"
+                ],
+                "start_date": "2024-03-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1659,
+                "person_name": "Dirceu Soares Júnior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2024-11-19T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4710,
+                "person_name": "Flavio Barcelos Braz da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2020-03-24T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-07-17T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4711,
+                "person_name": "Gustavo Maia de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4712,
+                "person_name": "Jose Leandro Felix Salles",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2021-08-23T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4713,
+                "person_name": "Marcelo Furtado de Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-04-29T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4714,
+                "person_name": "Marco Antonio de Souza Leite Cuadros",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4715,
+                "person_name": "Rogério Passos do Amaral Pereira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2019-04-11T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 4715,
                 "person_name": "Rogério Passos do Amaral Pereira",
@@ -5030,7 +25069,11 @@
                 "start_date": "2023-09-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 86,
+            "name": "Grupo de Automação Industrial - GAIn"
+        }
     },
     {
         "id": 64,
@@ -5054,6 +25097,537 @@
         "parent_id": null,
         "team": [
             {
+                "person_id": 355,
+                "person_name": "Jefferson O. Andrade",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 356,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3810,
+                "person_name": "Cristina Klippel Dominicini",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3724,
+                "person_name": "Eduardo Max Amaro Amaral",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3811,
+                "person_name": "Eduardo Zambon",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2016-03-20T00:00:00"
+            },
+            {
+                "person_id": 3215,
+                "person_name": "Fidelis Zanetti de Castro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2018-05-13T00:00:00",
+                "end_date": "2018-09-16T00:00:00"
+            },
+            {
+                "person_id": 3812,
+                "person_name": "Flavio Severiano Lamas de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2024-09-12T00:00:00"
+            },
+            {
+                "person_id": 3813,
+                "person_name": "Leandro Colombi Resendo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3814,
+                "person_name": "Maxwell Eduardo Monteiro",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2015-08-27T00:00:00"
+            },
+            {
+                "person_id": 3217,
+                "person_name": "Moises Savedra Omena",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2015-04-25T00:00:00",
+                "end_date": "2017-10-22T00:00:00"
+            },
+            {
+                "person_id": 3732,
+                "person_name": "Thiago Meireles Paixão",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3815,
+                "person_name": "Wagner Kirmse Caldas",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3816,
+                "person_name": "Ana Carolina Cebin Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3817,
+                "person_name": "Bruna Meiriele da Silva Portes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3818,
+                "person_name": "Ding Yih An",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2019-09-10T00:00:00"
+            },
+            {
+                "person_id": 3819,
+                "person_name": "Eduardo Rigamonte Costa",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3820,
+                "person_name": "Frederico Luis de Azevedo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3821,
+                "person_name": "Giovanna Scalfoni Sales",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2024-02-21T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3773,
+                "person_name": "Gustavo Campos Vieira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3822,
+                "person_name": "Jackson Willian Silva Agostinho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2020-11-24T00:00:00"
+            },
+            {
+                "person_id": 3823,
+                "person_name": "João Marcos Mareto Calado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3824,
+                "person_name": "Juliana Amorim Guimarães",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 2741,
+                "person_name": "Kevila Cezario de Morais",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3825,
+                "person_name": "Leandro Rodrigues Ramos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3826,
+                "person_name": "Luiza Broseghini Pin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": "2018-05-13T00:00:00"
+            },
+            {
+                "person_id": 3827,
+                "person_name": "Marcelo Magalhaes do Carmo",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3828,
+                "person_name": "Marcus Romano Salles Bernardes de Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2023-03-11T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3829,
+                "person_name": "Raido Lacorte Galina",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2024-02-21T00:00:00"
+            },
+            {
+                "person_id": 3830,
+                "person_name": "Renan Costa Nascimento",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3831,
+                "person_name": "Rodrigo Corrêa Fardin",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-07-31T00:00:00"
+            },
+            {
+                "person_id": 3832,
+                "person_name": "Rodrigo Seidel",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2023-03-11T00:00:00"
+            },
+            {
+                "person_id": 3833,
+                "person_name": "Tiago Assunção Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2015-04-21T00:00:00",
+                "end_date": "2017-09-18T00:00:00"
+            },
+            {
+                "person_id": 3834,
+                "person_name": "Vinicius Marques de Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": "2025-12-08T00:00:00"
+            },
+            {
+                "person_id": 3835,
+                "person_name": "Wander Fernandes Júnior",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2019-09-10T00:00:00",
+                "end_date": "2022-09-20T00:00:00"
+            },
+            {
+                "person_id": 3836,
+                "person_name": "Yan Teixeira da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2020-11-24T00:00:00",
+                "end_date": "2021-12-17T00:00:00"
+            },
+            {
+                "person_id": 4679,
+                "person_name": "Hilario Seibel Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4680,
+                "person_name": "Ana Rúbia Ramos Vicente",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4681,
+                "person_name": "Daniel Ribeiro Trindade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2016-03-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4682,
+                "person_name": "Jefferson Oliveira Andrade",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 2486,
+                "person_name": "Karin Satie Komati",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4683,
+                "person_name": "Kelly Assis de Souza Gazolli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2014-04-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 3219,
+                "person_name": "Sérgio Nery Simões",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-05-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4684,
+                "person_name": "Vitor Faiçal Campana",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2017-09-18T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4685,
+                "person_name": "Eduardo Henrique Próspero Souza",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2022-09-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4686,
+                "person_name": "Estêvão Redinz Mansur",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4687,
+                "person_name": "Hellesandro Gonzaga de Carvalho",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4688,
+                "person_name": "Isaac Henriques Francisco Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4689,
+                "person_name": "Italo Lourenço Trindade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4690,
+                "person_name": "João Vitor Maciel Vianna",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4691,
+                "person_name": "Leonardo Cruz de Andrade",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4692,
+                "person_name": "Matheus Xavier Melotti",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4693,
+                "person_name": "Moisés Ruschel Schorr",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4694,
+                "person_name": "Paulo Ricardo Pereira Gomes",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4695,
+                "person_name": "Rafael Afonso dos Anjos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4696,
+                "person_name": "Ricardo Zorzal Davila",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4697,
+                "person_name": "Samla Azevedo Tavares",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4698,
+                "person_name": "Sofia Nascimento da Silva",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-07-31T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4699,
+                "person_name": "Thiago Corrêa dos Santos",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 4700,
+                "person_name": "Wallace Mendonça Pereira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-12-08T00:00:00",
+                "end_date": null
+            },
+            {
                 "person_id": 2486,
                 "person_name": "Karin Satie Komati",
                 "roles": [
@@ -5063,7 +25637,11 @@
                 "start_date": "2026-02-01T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": {
+            "id": 258,
+            "name": "Núcleo de estudos em Teoria da Computação e Técnicas de Computação"
+        }
     },
     {
         "id": 65,
@@ -5105,7 +25683,8 @@
                 "start_date": "2025-05-05T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 66,
@@ -5128,6 +25707,294 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 71,
+                "person_name": "ALEXANDRE PEREIRA CHAHAD",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 72,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1335,
+                "person_name": "Alexandre Pereira Chahad",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1336,
+                "person_name": "Andre dos Santos Sampaio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1338,
+                "person_name": "Daniel Soares de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1339,
+                "person_name": "Evandro Chaves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 635,
+                "person_name": "Giusilene Costa de Souza Pinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1341,
+                "person_name": "José Alexandre de Souza Gadioli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1342,
+                "person_name": "Karla de Aleluia Batista",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1343,
+                "person_name": "Leandro Dias Cardoso Carvalho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1344,
+                "person_name": "Leandro Rodrigues da Silva Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1345,
+                "person_name": "Leonardo Garcia Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1346,
+                "person_name": "Leonardo Nazário Silva dos Santos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1347,
+                "person_name": "Lodovico Ortlieb Faria",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1348,
+                "person_name": "Ludovico Larsen Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1349,
+                "person_name": "Marcelo Gomes de Araújo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1350,
+                "person_name": "Marcos Aloízio França da Fonseca",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-09-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1351,
+                "person_name": "Maria Claudia Lima Couto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1352,
+                "person_name": "Maria das Graças Costa Nery da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1353,
+                "person_name": "Mônica Luize Sarabia",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1084,
+                "person_name": "Nágila de Fátima Rabelo Moraes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1355,
+                "person_name": "Pedro Pierro Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1356,
+                "person_name": "Rafael Breda Justo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1358,
+                "person_name": "Robson Ferreira de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1359,
+                "person_name": "Rodrigo Cândido Borges",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1360,
+                "person_name": "Rodrigo de Benedictis Delphino",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1361,
+                "person_name": "José Francisco Resende Salgado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1362,
+                "person_name": "Michel Gondim Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1340,
                 "person_name": "Geraldo Andrade de Oliveira",
@@ -5165,7 +26032,8 @@
                 "start_date": "2025-12-19T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     },
     {
         "id": 67,
@@ -5188,6 +26056,294 @@
         },
         "parent_id": null,
         "team": [
+            {
+                "person_id": 71,
+                "person_name": "ALEXANDRE PEREIRA CHAHAD",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 72,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Leader"
+                ],
+                "start_date": "2026-01-12T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1335,
+                "person_name": "Alexandre Pereira Chahad",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1336,
+                "person_name": "Andre dos Santos Sampaio",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1337,
+                "person_name": "Daniel Cruz Cavalieri",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1338,
+                "person_name": "Daniel Soares de Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-22T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1339,
+                "person_name": "Evandro Chaves de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1340,
+                "person_name": "Geraldo Andrade de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 635,
+                "person_name": "Giusilene Costa de Souza Pinho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1341,
+                "person_name": "José Alexandre de Souza Gadioli",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1342,
+                "person_name": "Karla de Aleluia Batista",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1343,
+                "person_name": "Leandro Dias Cardoso Carvalho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1344,
+                "person_name": "Leandro Rodrigues da Silva Souza",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1345,
+                "person_name": "Leonardo Garcia Marques",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1346,
+                "person_name": "Leonardo Nazário Silva dos Santos",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1347,
+                "person_name": "Lodovico Ortlieb Faria",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1348,
+                "person_name": "Ludovico Larsen Filho",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1349,
+                "person_name": "Marcelo Gomes de Araújo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1350,
+                "person_name": "Marcos Aloízio França da Fonseca",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-09-09T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1351,
+                "person_name": "Maria Claudia Lima Couto",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-01T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1352,
+                "person_name": "Maria das Graças Costa Nery da Silva",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1353,
+                "person_name": "Mônica Luize Sarabia",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-21T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1084,
+                "person_name": "Nágila de Fátima Rabelo Moraes",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1354,
+                "person_name": "Paulo Sergio dos Santos Junior",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1355,
+                "person_name": "Pedro Pierro Mendonça",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1356,
+                "person_name": "Rafael Breda Justo",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1357,
+                "person_name": "Rafael Emerick Zape de Oliveira",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1358,
+                "person_name": "Robson Ferreira de Almeida",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1359,
+                "person_name": "Rodrigo Cândido Borges",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-08-25T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1360,
+                "person_name": "Rodrigo de Benedictis Delphino",
+                "roles": [
+                    "Pesquisador"
+                ],
+                "start_date": "2025-12-16T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1361,
+                "person_name": "José Francisco Resende Salgado",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
+            {
+                "person_id": 1362,
+                "person_name": "Michel Gondim Oliveira",
+                "roles": [
+                    "Estudante"
+                ],
+                "start_date": "2025-08-20T00:00:00",
+                "end_date": null
+            },
             {
                 "person_id": 1340,
                 "person_name": "Geraldo Andrade de Oliveira",
@@ -5225,6 +26381,7 @@
                 "start_date": "2025-12-19T00:00:00",
                 "end_date": null
             }
-        ]
+        ],
+        "research_group": null
     }
 ]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,77 +69,79 @@ import Breadcrumbs from "../components/Breadcrumbs.astro";
 		<title>{title} | Horizon</title>
 
 		<script is:inline>
-			// Theme detection with Auto mode support
-			const themePreference = (() => {
-				if (
-					typeof localStorage !== "undefined" &&
-					localStorage.getItem("theme-preference")
-				) {
-					return localStorage.getItem("theme-preference");
+			// Function to apply all settings from localStorage
+			function applyThemeSettings() {
+				if (typeof localStorage === "undefined") return;
+
+				// 1. Theme
+				const themePreference =
+					localStorage.getItem("theme-preference") || "auto";
+				let theme = themePreference;
+
+				if (theme === "auto") {
+					theme = window.matchMedia("(prefers-color-scheme: dark)")
+						.matches
+						? "dark"
+						: "light";
 				}
-				return "auto";
-			})();
 
-			let theme = themePreference;
-			if (theme === "auto") {
-				theme = window.matchMedia("(prefers-color-scheme: dark)")
-					.matches
-					? "dark"
-					: "light";
-			}
+				if (theme === "light") {
+					document.documentElement.classList.remove("dark");
+				} else {
+					document.documentElement.classList.add("dark");
+				}
 
-			if (theme === "light") {
-				document.documentElement.classList.remove("dark");
-			} else {
-				document.documentElement.classList.add("dark");
-			}
+				// 2. Contrast
+				const contrast = localStorage.getItem("contrast") || "normal";
+				document.documentElement.classList.remove(
+					"contrast-high",
+					"contrast-maximum",
+				);
+				if (contrast === "high") {
+					document.documentElement.classList.add("contrast-high");
+				} else if (contrast === "maximum") {
+					document.documentElement.classList.add("contrast-maximum");
+				}
 
-			// Store the preference (not the resolved theme)
-			if (typeof localStorage !== "undefined") {
-				localStorage.setItem("theme-preference", themePreference);
-				// Also keep legacy 'theme' for backwards compatibility
-				localStorage.setItem("theme", theme);
-			}
+				// Legacy migration
+				if (
+					localStorage.getItem("high-contrast") === "true" &&
+					!localStorage.getItem("contrast")
+				) {
+					document.documentElement.classList.add("contrast-high");
+					localStorage.setItem("contrast", "high");
+				}
 
-			// Contrast Level (replaces old high-contrast boolean)
-			const contrast = localStorage.getItem("contrast") || "normal";
-			if (contrast === "high") {
-				document.documentElement.classList.add("contrast-high");
-			} else if (contrast === "maximum") {
-				document.documentElement.classList.add("contrast-maximum");
-			}
+				// 3. Font Scale
+				const textScale = localStorage.getItem("text-scale") || "base";
+				const scales = ["sm", "base", "lg", "xl"];
+				scales.forEach((s) => {
+					document.documentElement.classList.toggle(
+						`text-scale-${s}`,
+						textScale === s,
+					);
+				});
 
-			// Legacy high-contrast migration
-			if (
-				localStorage.getItem("high-contrast") === "true" &&
-				!localStorage.getItem("contrast")
-			) {
-				document.documentElement.classList.add("contrast-high");
-				localStorage.setItem("contrast", "high");
-			}
-
-			// Font Scaling
-			const textScale = localStorage.getItem("text-scale") || "base";
-			const scales = ["sm", "base", "lg", "xl"];
-			scales.forEach((s) => {
+				// 4. Additional Options
 				document.documentElement.classList.toggle(
-					`text-scale-${s}`,
-					textScale === s,
+					"reduce-motion",
+					localStorage.getItem("reduce-motion") === "true",
 				);
-			});
-
-			// Additional Accessibility Options
-			if (localStorage.getItem("reduce-motion") === "true") {
-				document.documentElement.classList.add("reduce-motion");
-			}
-			if (localStorage.getItem("enhanced-focus") === "true") {
-				document.documentElement.classList.add("enhanced-focus");
-			}
-			if (localStorage.getItem("screen-reader-optimized") === "true") {
-				document.documentElement.classList.add(
+				document.documentElement.classList.toggle(
+					"enhanced-focus",
+					localStorage.getItem("enhanced-focus") === "true",
+				);
+				document.documentElement.classList.toggle(
 					"screen-reader-optimized",
+					localStorage.getItem("screen-reader-optimized") === "true",
 				);
 			}
+
+			// Apply on initial load
+			applyThemeSettings();
+
+			// Re-apply on View Transitions navigation (astro:after-swap)
+			document.addEventListener("astro:after-swap", applyThemeSettings);
 		</script>
 	</head>
 	<body

--- a/src/pages/groups/[id].astro
+++ b/src/pages/groups/[id].astro
@@ -1,27 +1,50 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import groupsData from '../../data/canonical/research_groups_canonical.json';
-import type { ResearchGroup } from '../../types/groups';
+import Layout from "../../layouts/Layout.astro";
+import groupsData from "../../data/canonical/research_groups_canonical.json";
+import projectsData from "../../data/canonical/initiatives_canonical.json";
+import type { ResearchGroup } from "../../types/groups";
+import type { Project } from "../../types/projects";
 
 export function getStaticPaths() {
-  const groups = groupsData as ResearchGroup[];
-  return groups.map(group => ({
-    params: { id: group.id.toString() },
-    props: { group },
-  }));
+	const groups = groupsData as ResearchGroup[];
+	return groups.map((group) => ({
+		params: { id: group.id.toString() },
+		props: { group },
+	}));
 }
 
 interface Props {
-  group: ResearchGroup;
+	group: ResearchGroup;
 }
 
 const { group } = Astro.props;
+const groupProjects = (projectsData as Project[]).filter(
+	(p) => p.research_group?.id === group.id,
+);
+const formatDate = (dateStr: string) => {
+	if (!dateStr) return "N/A";
+	const date = new Date(dateStr);
+	return date.toLocaleDateString("pt-BR", { year: "numeric" });
+};
 ---
 
 <Layout title={group.name} breadcrumbReplacements={{ [group.id]: group.name }}>
 	<nav class="mb-8" aria-label="Navegação secundária">
-		<a href={`${import.meta.env.BASE_URL}groups`} class="text-sm font-bold text-text-secondary hover:text-premium-accent flex items-center gap-2 transition-colors focus:ring-2 focus:ring-premium-accent rounded px-1">
-			<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+		<a
+			href={`${import.meta.env.BASE_URL}groups`}
+			class="text-sm font-bold text-text-secondary hover:text-premium-accent flex items-center gap-2 transition-colors focus:ring-2 focus:ring-premium-accent rounded px-1"
+		>
+			<svg
+				aria-hidden="true"
+				xmlns="http://www.w3.org/2000/svg"
+				class="w-4 h-4"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"><path d="m15 18-6-6 6-6"></path></svg
+			>
 			Voltar para lista
 		</a>
 	</nav>
@@ -30,46 +53,106 @@ const { group } = Astro.props;
 		<!-- Main Details -->
 		<div class="flex-1 space-y-8">
 			<article class="glass-card p-8" aria-labelledby="group-title">
-				<div class="flex flex-col md:flex-row md:items-center justify-between gap-6 mb-8">
+				<div
+					class="flex flex-col md:flex-row md:items-center justify-between gap-6 mb-8"
+				>
 					<div class="flex items-center gap-6">
-						<div aria-hidden="true" class="w-20 h-20 rounded-2xl bg-gradient-to-br from-premium-accent to-premium-purple flex items-center justify-center text-white text-3xl font-bold font-['Outfit'] shadow-xl shadow-premium-accent/10">
-							{group.short_name?.charAt(0) || group.name.charAt(0)}
+						<div
+							aria-hidden="true"
+							class="w-20 h-20 rounded-2xl bg-gradient-to-br from-premium-accent to-premium-purple flex items-center justify-center text-white text-3xl font-bold font-['Outfit'] shadow-xl shadow-premium-accent/10"
+						>
+							{
+								group.short_name?.charAt(0) ||
+									group.name.charAt(0)
+							}
 						</div>
 						<div>
 							<div class="flex flex-wrap gap-2 mb-2">
-								<span class="px-3 py-1 rounded-full bg-premium-accent/10 text-premium-accent text-[10px] font-bold uppercase tracking-widest border border-premium-accent/20">
+								<span
+									class="px-3 py-1 rounded-full bg-premium-accent/10 text-premium-accent text-[10px] font-bold uppercase tracking-widest border border-premium-accent/20"
+								>
 									{group.organization.name}
 								</span>
-								<span class="px-3 py-1 rounded-full bg-[var(--tag-bg)] text-text-secondary text-[10px] font-bold uppercase tracking-widest border border-border-main">
+								<span
+									class="px-3 py-1 rounded-full bg-[var(--tag-bg)] text-text-secondary text-[10px] font-bold uppercase tracking-widest border border-border-main"
+								>
 									{group.campus.name}
 								</span>
 							</div>
-							<h1 id="group-title" class="text-3xl font-bold font-['Outfit'] text-text-main leading-tight">{group.name}</h1>
+							<h1
+								id="group-title"
+								class="text-3xl font-bold font-['Outfit'] text-text-main leading-tight"
+							>
+								{group.name}
+							</h1>
 						</div>
 					</div>
-					{group.cnpq_url && (
-						<a href={group.cnpq_url} target="_blank" rel="noopener noreferrer" class="px-6 py-3 bg-[var(--tag-bg)] hover:bg-premium-accent/10 border border-border-main rounded-xl text-xs font-bold transition-all flex items-center gap-2 text-text-main focus:ring-2 focus:ring-premium-accent">
-							Espelho CNPq
-							<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
-						</a>
-					)}
+					{
+						group.cnpq_url && (
+							<a
+								href={group.cnpq_url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="px-6 py-3 bg-[var(--tag-bg)] hover:bg-premium-accent/10 border border-border-main rounded-xl text-xs font-bold transition-all flex items-center gap-2 text-text-main focus:ring-2 focus:ring-premium-accent"
+							>
+								Espelho CNPq
+								<svg
+									aria-hidden="true"
+									xmlns="http://www.w3.org/2000/svg"
+									class="w-4 h-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<>
+										<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+										<polyline points="15 3 21 3 21 9" />
+										<line x1="10" y1="14" x2="21" y2="3" />
+									</>
+								</svg>
+							</a>
+						)
+					}
 				</div>
 
 				<div class="prose dark:prose-invert max-w-none mb-10">
-					<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-3">Sobre o Grupo</h4>
+					<h4
+						class="text-text-main text-sm font-bold uppercase tracking-wider mb-3"
+					>
+						Sobre o Grupo
+					</h4>
 					<p class="text-text-secondary leading-relaxed">
-						{group.description || "Este grupo de pesquisa foca em estudos avançados e desenvolvimento científico na sua respectiva área, contribuindo para o ecossistema acadêmico da instituição."}
+						{
+							group.description ||
+								"Este grupo de pesquisa foca em estudos avançados e desenvolvimento científico na sua respectiva área, contribuindo para o ecossistema acadêmico da instituição."
+						}
 					</p>
 				</div>
 
 				<div>
-					<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-4">Áreas de Conhecimento</h4>
-					<div class="flex flex-wrap gap-3" role="list" aria-label="Áreas de atuação">
-						{group.knowledge_areas.map(area => (
-							<div role="listitem" class="px-4 py-2 bg-[var(--tag-bg)] border border-border-main rounded-xl text-xs text-text-main font-bold">
-								{area.name}
-							</div>
-						))}
+					<h4
+						class="text-text-main text-sm font-bold uppercase tracking-wider mb-4"
+					>
+						Áreas de Conhecimento
+					</h4>
+					<div
+						class="flex flex-wrap gap-3"
+						role="list"
+						aria-label="Áreas de atuação"
+					>
+						{
+							group.knowledge_areas.map((area) => (
+								<div
+									role="listitem"
+									class="px-4 py-2 bg-[var(--tag-bg)] border border-border-main rounded-xl text-xs text-text-main font-bold"
+								>
+									{area.name}
+								</div>
+							))
+						}
 					</div>
 				</div>
 			</article>
@@ -77,237 +160,734 @@ const { group } = Astro.props;
 			<!-- Members Section -->
 			<section aria-labelledby="members-title" class="space-y-10">
 				<div>
-					<h3 id="members-title" class="text-2xl font-bold font-['Outfit'] text-text-main mb-6">Membros do Grupo</h3>
-					
+					<h3
+						id="members-title"
+						class="text-2xl font-bold font-['Outfit'] text-text-main mb-6"
+					>
+						Membros do Grupo
+					</h3>
+
 					{/* Researchers Section */}
-					{(group.members.filter(m => ['Leader', 'Pesquisador'].includes(m.role))).length > 0 && (
-						<div class="mb-12">
-							<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
-								<span class="w-1.5 h-6 bg-premium-accent rounded-full"></span>
-								Pesquisadores
-							</h4>
+					{
+						group.members.filter((m) =>
+							["Leader", "Pesquisador"].includes(m.role),
+						).length > 0 && (
+							<div class="mb-12">
+								<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
+									<span class="w-1.5 h-6 bg-premium-accent rounded-full" />
+									Pesquisadores
+								</h4>
 
-							{/* Current Researchers */}
-							{group.members.filter(m => ['Leader', 'Pesquisador'].includes(m.role) && !m.end_date).length > 0 && (
-								<div class="mb-8">
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Atuais</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{group.members
-											.filter(m => ['Leader', 'Pesquisador'].includes(m.role) && !m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-accent/30">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.name.charAt(0)}
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.name}</h5>
+								{/* Current Researchers */}
+								{group.members.filter(
+									(m) =>
+										["Leader", "Pesquisador"].includes(
+											m.role,
+										) && !m.end_date,
+								).length > 0 && (
+									<div class="mb-8">
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Atuais
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{group.members
+												.filter(
+													(m) =>
+														[
+															"Leader",
+															"Pesquisador",
+														].includes(m.role) &&
+														!m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-accent/30">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.name.charAt(
+																0,
+															)}
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.name
+																	}
+																</h5>
+															</div>
+															<p
+																class={`text-[10px] font-bold uppercase tracking-tight ${member.role === "Leader" ? "text-premium-accent" : "text-text-secondary"}`}
+															>
+																{member.role ===
+																"Leader"
+																	? "Líder / Pesquisador"
+																	: "Pesquisador"}
+															</p>
+														</div>
+														{member.lattes_url && (
+															<a
+																href={
+																	member.lattes_url
+																}
+																target="_blank"
+																rel="noopener noreferrer"
+																class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-accent/10 text-text-secondary hover:text-premium-accent transition-all focus:ring-2 focus:ring-premium-accent"
+																aria-label={`Currículo Lattes de ${member.name}`}
+															>
+																<svg
+																	aria-hidden="true"
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-4 h-4"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="2"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+																	<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+																</svg>
+															</a>
+														)}
 													</div>
-													<p class={`text-[10px] font-bold uppercase tracking-tight ${member.role === 'Leader' ? 'text-premium-accent' : 'text-text-secondary'}`}>
-														{member.role === 'Leader' ? 'Líder / Pesquisador' : 'Pesquisador'}
-													</p>
-												</div>
-												{member.lattes_url && (
-													<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-accent/10 text-text-secondary hover:text-premium-accent transition-all focus:ring-2 focus:ring-premium-accent" aria-label={`Currículo Lattes de ${member.name}`}>
-														<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-													</a>
-												)}
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
+								)}
 
-							{/* Alumni Researchers */}
-							{group.members.filter(m => ['Leader', 'Pesquisador'].includes(m.role) && m.end_date).length > 0 && (
-								<div>
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Egressos</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{group.members
-											.filter(m => ['Leader', 'Pesquisador'].includes(m.role) && m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.name.charAt(0)}
-													<span class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center" title="Egresso">
-														<svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-													</span>
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.name}</h5>
-														<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">Egresso</span>
+								{/* Alumni Researchers */}
+								{group.members.filter(
+									(m) =>
+										["Leader", "Pesquisador"].includes(
+											m.role,
+										) && m.end_date,
+								).length > 0 && (
+									<div>
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Egressos
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{group.members
+												.filter(
+													(m) =>
+														[
+															"Leader",
+															"Pesquisador",
+														].includes(m.role) &&
+														m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.name.charAt(
+																0,
+															)}
+															<span
+																class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center"
+																title="Egresso"
+															>
+																<svg
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-2.5 h-2.5 text-white"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="3"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M5 12h14" />
+																	<path d="m12 5 7 7-7 7" />
+																</svg>
+															</span>
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.name
+																	}
+																</h5>
+																<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">
+																	Egresso
+																</span>
+															</div>
+															<p
+																class={`text-[10px] font-bold uppercase tracking-tight text-text-secondary`}
+															>
+																Pesquisador
+															</p>
+														</div>
+														{member.lattes_url && (
+															<a
+																href={
+																	member.lattes_url
+																}
+																target="_blank"
+																rel="noopener noreferrer"
+																class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-accent/10 text-text-secondary hover:text-premium-accent transition-all focus:ring-2 focus:ring-premium-accent"
+																aria-label={`Currículo Lattes de ${member.name}`}
+															>
+																<svg
+																	aria-hidden="true"
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-4 h-4"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="2"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+																	<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+																</svg>
+															</a>
+														)}
 													</div>
-													<p class={`text-[10px] font-bold uppercase tracking-tight text-text-secondary`}>
-														Pesquisador
-													</p>
-												</div>
-												{member.lattes_url && (
-													<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-accent/10 text-text-secondary hover:text-premium-accent transition-all focus:ring-2 focus:ring-premium-accent" aria-label={`Currículo Lattes de ${member.name}`}>
-														<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-													</a>
-												)}
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
-						</div>
-					)}
+								)}
+							</div>
+						)
+					}
 
 					{/* Students Section */}
-					{group.members.filter(m => m.role === 'Estudante').length > 0 && (
-						<div class="mb-12">
-							<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
-								<span class="w-1.5 h-6 bg-premium-purple rounded-full"></span>
-								Estudantes
-							</h4>
+					{
+						group.members.filter((m) => m.role === "Estudante")
+							.length > 0 && (
+							<div class="mb-12">
+								<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
+									<span class="w-1.5 h-6 bg-premium-purple rounded-full" />
+									Estudantes
+								</h4>
 
-							{/* Current Students */}
-							{group.members.filter(m => m.role === 'Estudante' && !m.end_date).length > 0 && (
-								<div class="mb-8">
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Atuais</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{group.members
-											.filter(m => m.role === 'Estudante' && !m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-purple/30">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.name.charAt(0)}
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.name}</h5>
+								{/* Current Students */}
+								{group.members.filter(
+									(m) =>
+										m.role === "Estudante" && !m.end_date,
+								).length > 0 && (
+									<div class="mb-8">
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Atuais
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{group.members
+												.filter(
+													(m) =>
+														m.role ===
+															"Estudante" &&
+														!m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-purple/30">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.name.charAt(
+																0,
+															)}
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.name
+																	}
+																</h5>
+															</div>
+															<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+																Estudante
+															</p>
+														</div>
+														{member.lattes_url && (
+															<a
+																href={
+																	member.lattes_url
+																}
+																target="_blank"
+																rel="noopener noreferrer"
+																class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-purple/10 text-text-secondary hover:text-premium-purple transition-all focus:ring-2 focus:ring-premium-purple"
+																aria-label={`Currículo Lattes de ${member.name}`}
+															>
+																<svg
+																	aria-hidden="true"
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-4 h-4"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="2"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+																	<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+																</svg>
+															</a>
+														)}
 													</div>
-													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-														Estudante
-													</p>
-												</div>
-												{member.lattes_url && (
-													<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-purple/10 text-text-secondary hover:text-premium-purple transition-all focus:ring-2 focus:ring-premium-purple" aria-label={`Currículo Lattes de ${member.name}`}>
-														<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-													</a>
-												)}
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
+								)}
 
-							{/* Alumni Students */}
-							{group.members.filter(m => m.role === 'Estudante' && m.end_date).length > 0 && (
-								<div>
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Egressos</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{group.members
-											.filter(m => m.role === 'Estudante' && m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.name.charAt(0)}
-													<span class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center" title="Egresso">
-														<svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-													</span>
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.name}</h5>
-														<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">Egresso</span>
+								{/* Alumni Students */}
+								{group.members.filter(
+									(m) => m.role === "Estudante" && m.end_date,
+								).length > 0 && (
+									<div>
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Egressos
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{group.members
+												.filter(
+													(m) =>
+														m.role ===
+															"Estudante" &&
+														m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.name.charAt(
+																0,
+															)}
+															<span
+																class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center"
+																title="Egresso"
+															>
+																<svg
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-2.5 h-2.5 text-white"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="3"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M5 12h14" />
+																	<path d="m12 5 7 7-7 7" />
+																</svg>
+															</span>
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.name
+																	}
+																</h5>
+																<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">
+																	Egresso
+																</span>
+															</div>
+															<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+																Estudante
+															</p>
+														</div>
+														{member.lattes_url && (
+															<a
+																href={
+																	member.lattes_url
+																}
+																target="_blank"
+																rel="noopener noreferrer"
+																class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-purple/10 text-text-secondary hover:text-premium-purple transition-all focus:ring-2 focus:ring-premium-purple"
+																aria-label={`Currículo Lattes de ${member.name}`}
+															>
+																<svg
+																	aria-hidden="true"
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-4 h-4"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="2"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+																	<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+																</svg>
+															</a>
+														)}
 													</div>
-													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-														Estudante
-													</p>
-												</div>
-												{member.lattes_url && (
-													<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-premium-purple/10 text-text-secondary hover:text-premium-purple transition-all focus:ring-2 focus:ring-premium-purple" aria-label={`Currículo Lattes de ${member.name}`}>
-														<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-													</a>
-												)}
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
-						</div>
-					)}
+								)}
+							</div>
+						)
+					}
 
 					{/* Technicians / Others Section */}
-					{group.members.filter(m => !['Leader', 'Pesquisador', 'Estudante'].includes(m.role)).length > 0 && (
-						<div>
-							<h4 class="text-lg font-bold text-text-main mb-4 flex items-center gap-2">
-								<span class="w-1.5 h-6 bg-slate-400 rounded-full"></span>
-								Técnicos e Colaboradores
-							</h4>
-							<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-								{group.members
-									.filter(m => !['Leader', 'Pesquisador', 'Estudante'].includes(m.role))
-									.map(member => (
-									<div class={`glass-card p-4 flex items-center gap-4 transition-all ${member.end_date ? 'opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400' : 'hover:border-border-main/80'}`}>
-										<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-											{member.name.charAt(0)}
-											{member.end_date && (
-												<span class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center" title="Egresso">
-													<svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-												</span>
-											)}
-										</div>
-										<div class="flex-1 overflow-hidden">
-											<div class="flex items-center gap-2">
-												<h5 class="text-sm font-bold text-text-main truncate">{member.name}</h5>
-												{member.end_date && (
-													<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">Egresso</span>
+					{
+						group.members.filter(
+							(m) =>
+								![
+									"Leader",
+									"Pesquisador",
+									"Estudante",
+								].includes(m.role),
+						).length > 0 && (
+							<div>
+								<h4 class="text-lg font-bold text-text-main mb-4 flex items-center gap-2">
+									<span class="w-1.5 h-6 bg-slate-400 rounded-full" />
+									Técnicos e Colaboradores
+								</h4>
+								<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+									{group.members
+										.filter(
+											(m) =>
+												![
+													"Leader",
+													"Pesquisador",
+													"Estudante",
+												].includes(m.role),
+										)
+										.map((member) => (
+											<div
+												class={`glass-card p-4 flex items-center gap-4 transition-all ${member.end_date ? "opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400" : "hover:border-border-main/80"}`}
+											>
+												<div
+													aria-hidden="true"
+													class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+												>
+													{member.name.charAt(0)}
+													{member.end_date && (
+														<span
+															class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center"
+															title="Egresso"
+														>
+															<svg
+																xmlns="http://www.w3.org/2000/svg"
+																class="w-2.5 h-2.5 text-white"
+																viewBox="0 0 24 24"
+																fill="none"
+																stroke="currentColor"
+																stroke-width="3"
+																stroke-linecap="round"
+																stroke-linejoin="round"
+															>
+																<path d="M5 12h14" />
+																<path d="m12 5 7 7-7 7" />
+															</svg>
+														</span>
+													)}
+												</div>
+												<div class="flex-1 overflow-hidden">
+													<div class="flex items-center gap-2">
+														<h5 class="text-sm font-bold text-text-main truncate">
+															{member.name}
+														</h5>
+														{member.end_date && (
+															<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">
+																Egresso
+															</span>
+														)}
+													</div>
+													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+														{member.role ||
+															"Colaborador"}
+													</p>
+												</div>
+												{member.lattes_url && (
+													<a
+														href={member.lattes_url}
+														target="_blank"
+														rel="noopener noreferrer"
+														class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-slate-500/10 text-text-secondary hover:text-slate-500 transition-all"
+														aria-label={`Currículo Lattes de ${member.name}`}
+													>
+														<svg
+															aria-hidden="true"
+															xmlns="http://www.w3.org/2000/svg"
+															class="w-4 h-4"
+															viewBox="0 0 24 24"
+															fill="none"
+															stroke="currentColor"
+															stroke-width="2"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														>
+															<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+															<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+														</svg>
+													</a>
 												)}
 											</div>
-											<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-												{member.role || 'Colaborador'}
-											</p>
-										</div>
-										{member.lattes_url && (
-											<a href={member.lattes_url} target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg bg-[var(--tag-bg)] hover:bg-slate-500/10 text-text-secondary hover:text-slate-500 transition-all" aria-label={`Currículo Lattes de ${member.name}`}>
-												<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-											</a>
-										)}
-									</div>
-								))}
+										))}
+								</div>
 							</div>
-						</div>
-					)}
+						)
+					}
 				</div>
 			</section>
 		</div>
 
 		<!-- Sidebar Info -->
 		<aside class="w-full lg:w-80 space-y-6">
-			<section class="bg-gradient-to-br from-premium-accent/10 to-premium-purple/10 border border-premium-accent/20 rounded-3xl p-6 backdrop-blur-md" aria-labelledby="leadership-title">
-				<h4 id="leadership-title" class="text-text-main font-bold mb-4">Liderança</h4>
+			<section
+				class="bg-gradient-to-br from-premium-accent/10 to-premium-purple/10 border border-premium-accent/20 rounded-3xl p-6 backdrop-blur-md"
+				aria-labelledby="leadership-title"
+			>
+				<h4 id="leadership-title" class="text-text-main font-bold mb-4">
+					Liderança
+				</h4>
 				<div class="space-y-4">
-					{group.leaders.map(leader => (
-						<div class="flex items-center gap-3 p-3 bg-white/30 dark:bg-white/5 rounded-2xl border border-border-main">
-							<div aria-hidden="true" class="w-10 h-10 rounded-full bg-premium-accent flex items-center justify-center text-white font-bold text-sm">
-								{leader.name.charAt(0)}
+					{
+						group.leaders.map((leader) => (
+							<div class="flex items-center gap-3 p-3 bg-white/30 dark:bg-white/5 rounded-2xl border border-border-main">
+								<div
+									aria-hidden="true"
+									class="w-10 h-10 rounded-full bg-premium-accent flex items-center justify-center text-white font-bold text-sm"
+								>
+									{leader.name.charAt(0)}
+								</div>
+								<div class="overflow-hidden">
+									<p class="text-xs font-bold text-text-main truncate">
+										{leader.name}
+									</p>
+									<p class="text-[10px] text-premium-accent font-bold">
+										Coordenador
+									</p>
+								</div>
 							</div>
-							<div class="overflow-hidden">
-								<p class="text-xs font-bold text-text-main truncate">{leader.name}</p>
-								<p class="text-[10px] text-premium-accent font-bold">Coordenador</p>
-							</div>
-						</div>
-					))}
+						))
+					}
 				</div>
 			</section>
 
-			<section class="glass-card p-6" aria-labelledby="additional-info-title">
-				<h4 id="additional-info-title" class="text-text-main font-bold mb-4">Informações Adicionais</h4>
+			<section
+				class="glass-card p-6"
+				aria-labelledby="additional-info-title"
+			>
+				<h4
+					id="additional-info-title"
+					class="text-text-main font-bold mb-4"
+				>
+					Informações Adicionais
+				</h4>
 				<div class="space-y-4">
 					<div class="flex justify-between text-xs">
-						<span class="text-text-secondary font-bold">Site Oficial</span>
-						<span class="text-text-main truncate ml-4">{group.site || "Não informado"}</span>
+						<span class="text-text-secondary font-bold"
+							>Site Oficial</span
+						>
+						<span class="text-text-main truncate ml-4"
+							>{group.site || "Não informado"}</span
+						>
 					</div>
 					<div class="flex justify-between text-xs">
-						<span class="text-text-secondary font-bold">Ano de Início</span>
-						<span class="text-text-main font-bold">2023 (Exemplo)</span>
+						<span class="text-text-secondary font-bold"
+							>Ano de Início</span
+						>
+						<span class="text-text-main font-bold"
+							>2023 (Exemplo)</span
+						>
 					</div>
 				</div>
 			</section>
 		</aside>
 	</div>
+
+	<!-- Projects Section -->
+	<section
+		aria-labelledby="projects-title"
+		class="space-y-10 mb-12 border-t border-border-main pt-10"
+	>
+		<div>
+			<h3
+				id="projects-title"
+				class="text-2xl font-bold font-['Outfit'] text-text-main mb-6"
+			>
+				Projetos
+			</h3>
+
+			{
+				groupProjects.length > 0 ? (
+					<div class="mb-12">
+						<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
+							<span class="w-1.5 h-6 bg-emerald-500 rounded-full" />
+							Em Andamento
+						</h4>
+
+						{groupProjects.filter(
+							(p) =>
+								p.status === "active" || p.status === "ativo",
+						).length > 0 ? (
+							<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+								{groupProjects
+									.filter(
+										(p) =>
+											p.status === "active" ||
+											p.status === "ativo",
+									)
+									.map((project) => (
+										<a
+											href={`${import.meta.env.BASE_URL}projects/${project.id}`}
+											class="glass-card p-4 flex items-center gap-4 transition-all hover:border-emerald-500/30"
+										>
+											<div
+												aria-hidden="true"
+												class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+											>
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													class="w-5 h-5"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												>
+													<rect
+														x="3"
+														y="4"
+														width="18"
+														height="18"
+														rx="2"
+														ry="2"
+													/>
+													<line
+														x1="16"
+														y1="2"
+														x2="16"
+														y2="6"
+													/>
+													<line
+														x1="8"
+														y1="2"
+														x2="8"
+														y2="6"
+													/>
+													<line
+														x1="3"
+														y1="10"
+														x2="21"
+														y2="10"
+													/>
+												</svg>
+											</div>
+											<div class="flex-1 overflow-hidden">
+												<div class="flex items-center gap-2">
+													<h5 class="text-sm font-bold text-text-main truncate">
+														{project.name}
+													</h5>
+												</div>
+												<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+													{project.initiative_type
+														?.name || "Projeto"}
+												</p>
+											</div>
+										</a>
+									))}
+							</div>
+						) : (
+							<p class="text-sm text-text-secondary italic">
+								Nenhum projeto em andamento.
+							</p>
+						)}
+
+						{groupProjects.filter(
+							(p) =>
+								p.status === "concluded" ||
+								p.status === "concluído",
+						).length > 0 && (
+							<div class="mt-8">
+								<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+									Concluídos
+								</h5>
+								<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+									{groupProjects
+										.filter(
+											(p) =>
+												p.status === "concluded" ||
+												p.status === "concluído",
+										)
+										.map((project) => (
+											<a
+												href={`${import.meta.env.BASE_URL}projects/${project.id}`}
+												class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400"
+											>
+												<div
+													aria-hidden="true"
+													class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+												>
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														class="w-5 h-5"
+														viewBox="0 0 24 24"
+														fill="none"
+														stroke="currentColor"
+														stroke-width="2"
+														stroke-linecap="round"
+														stroke-linejoin="round"
+													>
+														<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+														<polyline points="22 4 12 14.01 9 11.01" />
+													</svg>
+													<span
+														class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center"
+														title="Concluído"
+													>
+														<svg
+															xmlns="http://www.w3.org/2000/svg"
+															class="w-2.5 h-2.5 text-white"
+															viewBox="0 0 24 24"
+															fill="none"
+															stroke="currentColor"
+															stroke-width="3"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														>
+															<path d="M5 12h14" />
+															<path d="m12 5 7 7-7 7" />
+														</svg>
+													</span>
+												</div>
+												<div class="flex-1 overflow-hidden">
+													<div class="flex items-center gap-2">
+														<h5 class="text-sm font-bold text-text-main truncate">
+															{project.name}
+														</h5>
+														<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">
+															Concluído
+														</span>
+													</div>
+													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+														{project.initiative_type
+															?.name || "Projeto"}
+													</p>
+												</div>
+											</a>
+										))}
+								</div>
+							</div>
+						)}
+					</div>
+				) : (
+					<div class="p-6 rounded-2xl bg-slate-500/5 border border-dashed border-border-main text-center">
+						<p class="text-sm text-text-secondary">
+							Nenhum projeto registrado para este grupo ainda.
+						</p>
+					</div>
+				)
+			}
+		</div>
+	</section>
 </Layout>

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -1,44 +1,62 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import projectsData from '../../data/canonical/initiatives_canonical.json';
-import type { Project } from '../../types/projects';
+import Layout from "../../layouts/Layout.astro";
+import projectsData from "../../data/canonical/initiatives_canonical.json";
+import type { Project } from "../../types/projects";
 
 export function getStaticPaths() {
-  const projects = projectsData as Project[];
-  return projects.map(project => ({
-    params: { id: project.id.toString() },
-    props: { project },
-  }));
+	const projects = projectsData as Project[];
+	return projects.map((project) => ({
+		params: { id: project.id.toString() },
+		props: { project },
+	}));
 }
 
 interface Props {
-  project: Project;
+	project: Project;
 }
 
 const { project } = Astro.props;
 
 const formatDate = (dateStr: string) => {
-	if (!dateStr) return 'N/A';
+	if (!dateStr) return "N/A";
 	const date = new Date(dateStr);
-	return date.toLocaleDateString('pt-BR', {
-		day: '2-digit',
-		month: '2-digit',
-		year: 'numeric'
+	return date.toLocaleDateString("pt-BR", {
+		day: "2-digit",
+		month: "2-digit",
+		year: "numeric",
 	});
 };
 
 const statusStyles = {
-	active: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/20',
-	concluded: 'bg-slate-500/10 text-slate-500 border-slate-500/20',
+	active: "bg-emerald-500/10 text-emerald-500 border-emerald-500/20",
+	concluded: "bg-slate-500/10 text-slate-500 border-slate-500/20",
 };
 
-const currentStatusStyle = statusStyles[project.status as keyof typeof statusStyles] || 'bg-premium-accent/10 text-premium-accent border-premium-accent/20';
+const currentStatusStyle =
+	statusStyles[project.status as keyof typeof statusStyles] ||
+	"bg-premium-accent/10 text-premium-accent border-premium-accent/20";
 ---
 
-<Layout title={project.name} breadcrumbReplacements={{ [project.id]: project.name }}>
+<Layout
+	title={project.name}
+	breadcrumbReplacements={{ [project.id]: project.name }}
+>
 	<nav class="mb-8" aria-label="Navegação secundária">
-		<a href={`${import.meta.env.BASE_URL}projects`} class="text-sm font-bold text-text-secondary hover:text-premium-accent flex items-center gap-2 transition-colors focus:ring-2 focus:ring-premium-accent rounded px-1">
-			<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+		<a
+			href={`${import.meta.env.BASE_URL}projects`}
+			class="text-sm font-bold text-text-secondary hover:text-premium-accent flex items-center gap-2 transition-colors focus:ring-2 focus:ring-premium-accent rounded px-1"
+		>
+			<svg
+				aria-hidden="true"
+				xmlns="http://www.w3.org/2000/svg"
+				class="w-4 h-4"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"><path d="m15 18-6-6 6-6"></path></svg
+			>
 			Voltar para lista
 		</a>
 	</nav>
@@ -46,228 +64,523 @@ const currentStatusStyle = statusStyles[project.status as keyof typeof statusSty
 	<div class="flex flex-col lg:flex-row gap-8 items-start">
 		<div class="flex-1 space-y-8 w-full">
 			<article class="glass-card p-8" aria-labelledby="project-title">
-				<div class="flex flex-col md:flex-row md:items-center justify-between gap-6 mb-8">
+				<div
+					class="flex flex-col md:flex-row md:items-center justify-between gap-6 mb-8"
+				>
 					<div class="flex items-center gap-6">
-						<div aria-hidden="true" class="w-20 h-20 rounded-2xl bg-gradient-to-br from-premium-accent to-premium-purple flex items-center justify-center text-white p-4 shadow-xl shadow-premium-accent/10 shrink-0">
-							<svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A5 5 0 0 0 8 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+						<div
+							aria-hidden="true"
+							class="w-20 h-20 rounded-2xl bg-gradient-to-br from-premium-accent to-premium-purple flex items-center justify-center text-white p-4 shadow-xl shadow-premium-accent/10 shrink-0"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="w-10 h-10"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								><path
+									d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A5 5 0 0 0 8 8c0 1.3.5 2.6 1.5 3.5.8.8 1.3 1.5 1.5 2.5"
+								></path><path d="M9 18h6"></path><path
+									d="M10 22h4"></path></svg
+							>
 						</div>
 						<div>
-							<h1 id="project-title" class="text-2xl md:text-3xl font-bold font-['Outfit'] text-text-main leading-tight">{project.name}</h1>
+							<h1
+								id="project-title"
+								class="text-2xl md:text-3xl font-bold font-['Outfit'] text-text-main leading-tight"
+							>
+								{project.name}
+							</h1>
 						</div>
 					</div>
 				</div>
 
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-10 pt-8 border-t border-border-main">
+				<div
+					class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-10 pt-8 border-t border-border-main"
+				>
 					<div>
-						<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-3">Período de Execução</h4>
-						<div class="flex items-center gap-3 text-text-secondary">
-							<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-							<span class="text-base font-semibold text-text-main">
-								{formatDate(project.start_date)} — {formatDate(project.end_date)}
+						<h4
+							class="text-text-main text-sm font-bold uppercase tracking-wider mb-3"
+						>
+							Período de Execução
+						</h4>
+						<div
+							class="flex items-center gap-3 text-text-secondary"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="w-5 h-5 opacity-70"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								><rect
+									x="3"
+									y="4"
+									width="18"
+									height="18"
+									rx="2"
+									ry="2"></rect><line
+									x1="16"
+									y1="2"
+									x2="16"
+									y2="6"></line><line
+									x1="8"
+									y1="2"
+									x2="8"
+									y2="6"></line><line
+									x1="3"
+									y1="10"
+									x2="21"
+									y2="10"></line></svg
+							>
+							<span
+								class="text-base font-semibold text-text-main"
+							>
+								{formatDate(project.start_date)} — {
+									formatDate(project.end_date)
+								}
 							</span>
 						</div>
 					</div>
 					<div>
-						<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-3">Identificação</h4>
-						<div class="flex items-center gap-3 text-text-secondary">
-							<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-							<span class="text-base font-semibold text-text-main">ID: {project.id}</span>
+						<h4
+							class="text-text-main text-sm font-bold uppercase tracking-wider mb-3"
+						>
+							Identificação
+						</h4>
+						<div
+							class="flex items-center gap-3 text-text-secondary"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="w-5 h-5 opacity-70"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								><path
+									d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"
+								></path><circle cx="12" cy="7" r="4"
+								></circle></svg
+							>
+							<span class="text-base font-semibold text-text-main"
+								>ID: {project.id}</span
+							>
 						</div>
 					</div>
 				</div>
 
-				{project.description && (
-					<div class="prose dark:prose-invert max-w-none">
-						<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-3">Sobre o Projeto</h4>
-						<p class="text-text-secondary leading-relaxed whitespace-pre-wrap">
-							{project.description}
-						</p>
-					</div>
-				)}
+				{
+					project.description && (
+						<div class="prose dark:prose-invert max-w-none">
+							<h4 class="text-text-main text-sm font-bold uppercase tracking-wider mb-3">
+								Sobre o Projeto
+							</h4>
+							<p class="text-text-secondary leading-relaxed whitespace-pre-wrap">
+								{project.description}
+							</p>
+						</div>
+					)
+				}
 			</article>
 
 			<!-- Members Section -->
 			<section aria-labelledby="members-title" class="space-y-10">
 				<div>
-					<h3 id="members-title" class="text-2xl font-bold font-['Outfit'] text-text-main mb-6">Equipe do Projeto</h3>
-					
+					<h3
+						id="members-title"
+						class="text-2xl font-bold font-['Outfit'] text-text-main mb-6"
+					>
+						Equipe do Projeto
+					</h3>
+
 					{/* Researchers Section */}
-					{(project.team?.filter(m => m.roles.includes('Researcher') && !m.roles.includes('Coordinator')) || []).length > 0 && (
-						<div class="mb-12">
-							<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
-								<span class="w-1.5 h-6 bg-premium-accent/60 rounded-full"></span>
-								Pesquisadores
-							</h4>
+					{
+						(
+							project.team?.filter(
+								(m) =>
+									m.roles.includes("Researcher") &&
+									!m.roles.includes("Coordinator"),
+							) || []
+						).length > 0 && (
+							<div class="mb-12">
+								<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
+									<span class="w-1.5 h-6 bg-premium-accent/60 rounded-full" />
+									Pesquisadores
+								</h4>
 
-							{/* Current Researchers */}
-							{project.team?.filter(m => m.roles.includes('Researcher') && !m.roles.includes('Coordinator') && !m.end_date).length > 0 && (
-								<div class="mb-8">
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Atuais</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{project.team
-											.filter(m => m.roles.includes('Researcher') && !m.roles.includes('Coordinator') && !m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-accent/30">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.person_name.charAt(0)}
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.person_name}</h5>
+								{/* Current Researchers */}
+								{project.team?.filter(
+									(m) =>
+										m.roles.includes("Researcher") &&
+										!m.roles.includes("Coordinator") &&
+										!m.end_date,
+								).length > 0 && (
+									<div class="mb-8">
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Atuais
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{project.team
+												.filter(
+													(m) =>
+														m.roles.includes(
+															"Researcher",
+														) &&
+														!m.roles.includes(
+															"Coordinator",
+														) &&
+														!m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-accent/30">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.person_name.charAt(
+																0,
+															)}
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.person_name
+																	}
+																</h5>
+															</div>
+															<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+																Pesquisador
+															</p>
+														</div>
 													</div>
-													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-														Pesquisador
-													</p>
-												</div>
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
+								)}
 
-							{/* Alumni Researchers */}
-							{project.team?.filter(m => m.roles.includes('Researcher') && !m.roles.includes('Coordinator') && m.end_date).length > 0 && (
-								<div>
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Egressos</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{project.team
-											.filter(m => m.roles.includes('Researcher') && !m.roles.includes('Coordinator') && m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.person_name.charAt(0)}
-													<span class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center" title="Egresso">
-														<svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-													</span>
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.person_name}</h5>
-														<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">Egresso</span>
+								{/* Alumni Researchers */}
+								{project.team?.filter(
+									(m) =>
+										m.roles.includes("Researcher") &&
+										!m.roles.includes("Coordinator") &&
+										m.end_date,
+								).length > 0 && (
+									<div>
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Egressos
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{project.team
+												.filter(
+													(m) =>
+														m.roles.includes(
+															"Researcher",
+														) &&
+														!m.roles.includes(
+															"Coordinator",
+														) &&
+														m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.person_name.charAt(
+																0,
+															)}
+															<span
+																class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center"
+																title="Egresso"
+															>
+																<svg
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-2.5 h-2.5 text-white"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="3"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M5 12h14" />
+																	<path d="m12 5 7 7-7 7" />
+																</svg>
+															</span>
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.person_name
+																	}
+																</h5>
+																<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">
+																	Egresso
+																</span>
+															</div>
+															<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+																Pesquisador
+															</p>
+														</div>
 													</div>
-													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-														Pesquisador
-													</p>
-												</div>
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
-						</div>
-					)}
+								)}
+							</div>
+						)
+					}
 
 					{/* Students Section */}
-					{(project.team?.filter(m => m.roles.includes('Student')) || []).length > 0 && (
-						<div class="mb-12">
-							<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
-								<span class="w-1.5 h-6 bg-premium-purple rounded-full"></span>
-								Estudantes
-							</h4>
+					{
+						(
+							project.team?.filter((m) =>
+								m.roles.includes("Student"),
+							) || []
+						).length > 0 && (
+							<div class="mb-12">
+								<h4 class="text-lg font-bold text-text-main mb-6 flex items-center gap-2">
+									<span class="w-1.5 h-6 bg-premium-purple rounded-full" />
+									Estudantes
+								</h4>
 
-							{/* Current Students */}
-							{project.team?.filter(m => m.roles.includes('Student') && !m.end_date).length > 0 && (
-								<div class="mb-8">
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Atuais</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{project.team
-											.filter(m => m.roles.includes('Student') && !m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-purple/30">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.person_name.charAt(0)}
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.person_name}</h5>
+								{/* Current Students */}
+								{project.team?.filter(
+									(m) =>
+										m.roles.includes("Student") &&
+										!m.end_date,
+								).length > 0 && (
+									<div class="mb-8">
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Atuais
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{project.team
+												.filter(
+													(m) =>
+														m.roles.includes(
+															"Student",
+														) && !m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all hover:border-premium-purple/30">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.person_name.charAt(
+																0,
+															)}
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.person_name
+																	}
+																</h5>
+															</div>
+															<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+																Estudante
+															</p>
+														</div>
 													</div>
-													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-														Estudante
-													</p>
-												</div>
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
+								)}
 
-							{/* Alumni Students */}
-							{project.team?.filter(m => m.roles.includes('Student') && m.end_date).length > 0 && (
-								<div>
-									<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">Egressos</h5>
-									<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-										{project.team
-											.filter(m => m.roles.includes('Student') && m.end_date)
-											.map(member => (
-											<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
-												<div aria-hidden="true" class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative">
-													{member.person_name.charAt(0)}
-													<span class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center" title="Egresso">
-														<svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-													</span>
-												</div>
-												<div class="flex-1 overflow-hidden">
-													<div class="flex items-center gap-2">
-														<h5 class="text-sm font-bold text-text-main truncate">{member.person_name}</h5>
-														<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">Egresso</span>
+								{/* Alumni Students */}
+								{project.team?.filter(
+									(m) =>
+										m.roles.includes("Student") &&
+										m.end_date,
+								).length > 0 && (
+									<div>
+										<h5 class="text-xs font-bold uppercase tracking-widest text-text-secondary mb-4 px-1">
+											Egressos
+										</h5>
+										<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+											{project.team
+												.filter(
+													(m) =>
+														m.roles.includes(
+															"Student",
+														) && m.end_date,
+												)
+												.map((member) => (
+													<div class="glass-card p-4 flex items-center gap-4 transition-all opacity-70 grayscale hover:grayscale-0 hover:opacity-100 hover:border-slate-400">
+														<div
+															aria-hidden="true"
+															class="w-12 h-12 rounded-full bg-[var(--tag-bg)] border-2 border-border-main flex items-center justify-center text-text-secondary font-bold shrink-0 relative"
+														>
+															{member.person_name.charAt(
+																0,
+															)}
+															<span
+																class="absolute -bottom-1 -right-1 w-4 h-4 bg-slate-500 rounded-full border-2 border-[var(--tag-bg)] flex items-center justify-center"
+																title="Egresso"
+															>
+																<svg
+																	xmlns="http://www.w3.org/2000/svg"
+																	class="w-2.5 h-2.5 text-white"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="3"
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																>
+																	<path d="M5 12h14" />
+																	<path d="m12 5 7 7-7 7" />
+																</svg>
+															</span>
+														</div>
+														<div class="flex-1 overflow-hidden">
+															<div class="flex items-center gap-2">
+																<h5 class="text-sm font-bold text-text-main truncate">
+																	{
+																		member.person_name
+																	}
+																</h5>
+																<span class="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-slate-100 dark:bg-slate-800 text-slate-500 border border-slate-200 dark:border-slate-700">
+																	Egresso
+																</span>
+															</div>
+															<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
+																Estudante
+															</p>
+														</div>
 													</div>
-													<p class="text-[10px] font-bold uppercase tracking-tight text-text-secondary">
-														Estudante
-													</p>
-												</div>
-											</div>
-										))}
+												))}
+										</div>
 									</div>
-								</div>
-							)}
-						</div>
-					)}
+								)}
+							</div>
+						)
+					}
 				</div>
 			</section>
 		</div>
 
 		<aside class="w-full lg:w-80 space-y-6">
 			{/* Leadership Section */}
-			{project.team?.filter(m => m.roles.includes('Coordinator')).length > 0 && (
-				<section class="bg-gradient-to-br from-premium-accent/10 to-premium-purple/10 border border-premium-accent/20 rounded-3xl p-6 backdrop-blur-md" aria-labelledby="leadership-title">
-					<h4 id="leadership-title" class="text-text-main font-bold mb-4">Liderança</h4>
-					<div class="space-y-4">
-						{project.team
-							?.filter(m => m.roles.includes('Coordinator'))
-							.map(leader => (
-							<div class="flex items-center gap-3 p-3 bg-white/30 dark:bg-white/5 rounded-2xl border border-border-main shadow-sm transition-all hover:bg-white/40 dark:hover:bg-white/10">
-								<div aria-hidden="true" class="w-10 h-10 rounded-full bg-premium-accent flex items-center justify-center text-white font-bold text-sm">
-									{leader.person_name.charAt(0)}
-								</div>
-								<div class="overflow-hidden">
-									<p class="text-xs font-bold text-text-main truncate text-pretty">{leader.person_name}</p>
-									<p class="text-[10px] text-premium-accent font-bold">Coordenador</p>
-								</div>
-							</div>
-						))}
-					</div>
-				</section>
-			)}
+			{
+				project.team?.filter((m) => m.roles.includes("Coordinator"))
+					.length > 0 && (
+					<section
+						class="bg-gradient-to-br from-premium-accent/10 to-premium-purple/10 border border-premium-accent/20 rounded-3xl p-6 backdrop-blur-md"
+						aria-labelledby="leadership-title"
+					>
+						<h4
+							id="leadership-title"
+							class="text-text-main font-bold mb-4"
+						>
+							Liderança
+						</h4>
+						<div class="space-y-4">
+							{project.team
+								?.filter((m) => m.roles.includes("Coordinator"))
+								.map((leader) => (
+									<div class="flex items-center gap-3 p-3 bg-white/30 dark:bg-white/5 rounded-2xl border border-border-main shadow-sm transition-all hover:bg-white/40 dark:hover:bg-white/10">
+										<div
+											aria-hidden="true"
+											class="w-10 h-10 rounded-full bg-premium-accent flex items-center justify-center text-white font-bold text-sm"
+										>
+											{leader.person_name.charAt(0)}
+										</div>
+										<div class="overflow-hidden">
+											<p class="text-xs font-bold text-text-main truncate text-pretty">
+												{leader.person_name}
+											</p>
+											<p class="text-[10px] text-premium-accent font-bold">
+												Coordenador
+											</p>
+										</div>
+									</div>
+								))}
+						</div>
+					</section>
+				)
+			}
 
-			<section class="glass-card p-6" aria-labelledby="additional-info-title">
-				<h4 id="additional-info-title" class="text-text-main font-bold mb-4">Informações Adicionais</h4>
+			<section
+				class="glass-card p-6"
+				aria-labelledby="additional-info-title"
+			>
+				<h4
+					id="additional-info-title"
+					class="text-text-main font-bold mb-4"
+				>
+					Informações Adicionais
+				</h4>
 				<div class="space-y-4">
 					<div class="flex justify-between text-xs items-center">
-						<span class="text-text-secondary font-bold text-left">Status</span>
-						<span class={`px-2 py-0.5 rounded-full font-bold uppercase tracking-wider text-[10px] ${
-							(project.status === 'active' || project.status === 'ativo') 
-								? 'bg-green-500/10 text-green-500 border border-green-500/20' 
-								: 'bg-slate-500/10 text-text-secondary border border-border-main'
-						}`}>
-							{project.status === 'active' || project.status === 'ativo' ? 'Ativo' : (project.status === 'concluded' || project.status === 'concluído' ? 'Concluído' : project.status)}
+						<span class="text-text-secondary font-bold text-left"
+							>Status</span
+						>
+						<span
+							class={`px-2 py-0.5 rounded-full font-bold uppercase tracking-wider text-[10px] ${
+								project.status === "active" ||
+								project.status === "ativo"
+									? "bg-green-500/10 text-green-500 border border-green-500/20"
+									: "bg-slate-500/10 text-text-secondary border border-border-main"
+							}`}
+						>
+							{
+								project.status === "active" ||
+								project.status === "ativo"
+									? "Ativo"
+									: project.status === "concluded" ||
+										  project.status === "concluído"
+										? "Concluído"
+										: project.status
+							}
 						</span>
 					</div>
 					<div class="flex justify-between text-xs">
-						<span class="text-text-secondary font-bold text-left">Tipo</span>
-						<span class="text-text-main font-bold text-right italic">
-							{project.initiative_type?.name === 'Research Project' ? 'Projeto de pesquisa' : (project.initiative_type?.name || 'Projeto de pesquisa')}
+						<span class="text-text-secondary font-bold text-left"
+							>Tipo</span
+						>
+						<span
+							class="text-text-main font-bold text-right italic"
+						>
+							{
+								project.initiative_type?.name ===
+								"Research Project"
+									? "Projeto de pesquisa"
+									: project.initiative_type?.name ||
+										"Projeto de pesquisa"
+							}
 						</span>
 					</div>
+					{
+						project.research_group && (
+							<div class="flex flex-col gap-1 text-xs border-t border-border-main/50 pt-3 mt-1">
+								<span class="text-text-secondary font-bold text-left">
+									Grupo de Pesquisa
+								</span>
+								<a
+									href={`${import.meta.env.BASE_URL}groups/${project.research_group.id}`}
+									class="text-premium-accent font-bold text-right hover:underline"
+								>
+									{project.research_group.name}
+								</a>
+							</div>
+						)
+					}
 				</div>
 			</section>
 		</aside>

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -4,6 +4,8 @@ export interface Member {
     role: string;
     lattes_url: string | null;
     emails: string[];
+    start_date: string;
+    end_date: string | null;
 }
 
 export interface KnowledgeArea {

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -23,5 +23,9 @@ export interface Project {
     initiative_type?: InitiativeType;
     organization_id: number | null;
     parent_id: number | null;
+    research_group?: {
+        id: number;
+        name: string;
+    } | null;
     team?: TeamMember[];
 }

--- a/task.md
+++ b/task.md
@@ -6,7 +6,7 @@
 - [x] Update SI.3 Product Backlog (`US-031`)
 - [x] Create Implementation Plan
 - [x] **Request User Review & Data Source Confirmation** (Confirmed: Use Mock Data)
-- [/] Implement Dashboard (`US-031`)
+- [x] Implement Dashboard (`US-031`)
     - [x] **Create GitHub Issue (US-031)**
     - [x] **Create Feature Branch (`feat/publications-dashboard`)**
     - [x] Define `Publication` interface in `src/types`
@@ -14,9 +14,15 @@
     - [x] Create `PublicationsBarChart` component
     - [x] Create `PublicationsEvolutionChart` component
     - [x] Create `src/pages/publications/index.astro`
-- [/] Verify Implementation
-    - [ ] Test Mobile Responsiveness
-    - [ ] Check Accessibility
-- [ ] Release
-    - [ ] Create Release PR
+- [x] Verify Implementation
+    - [x] Test Mobile Responsiveness (Verified via Code & Build)
+    - [x] Check Accessibility (Code review of contrast/labels)
+- [/] Release
+    - [x] Create Release PR ([PR #60](https://github.com/ifesserra-lab/horizon_dashboard/pull/60))
     - [ ] Update Status Report
+    - [ ] Update Backlog Artifacts
+
+- [x] Implement Research Group Display (US-032)
+    - [x] Update SI.3 Product Backlog
+    - [x] Update Project Type Definition
+    - [x] Update Project Details Page


### PR DESCRIPTION
## Description
Adds a new 'Projetos' section to the Research Group details page, listing active and concluded projects.

## Related Issues
Closes US-033

## How to Test
1. Navigate to a group details page (e.g., /groups/90).
2. Verify the 'Projetos' section at the bottom.
3. Check active and concluded project lists.