### PR TITLE
fix(cicd): refactor deploy workflow to explicit steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,17 +23,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install, build, and upload
-        uses: withastro/action@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-            path: .
-            node-version: 20
-            package-manager: npm
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description
This PR refactors the deployment workflow to use explicit steps instead of `withastro/action`. This is intended to fix the CI/CD error where multiple "github-pages" artifacts are found during a single run.

### Changes:
- Replaced `withastro/action` with manual Setup Node, Build, and `upload-pages-artifact` steps.
- This provides better control over artifact naming and avoids collision bugs in high-level actions.

Closes # [Insert Issue ID if available]