### PR TITLE
release: fix cicd deployment artifact collision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,17 +23,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install, build, and upload
-        uses: withastro/action@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-            path: .
-            node-version: 20
-            package-manager: npm
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Release PR (Fix)
This release fixes the CI/CD artifact collision error in the deployment workflow.

### Fix:
- Refactored `deploy.yml` to use explicit build and upload steps.
- This resolves the "Multiple artifacts named github-pages found" error which was preventing deployment to GitHub Pages.

Merged from `developing` (PR #82).